### PR TITLE
feat: Add 'From the Desk' feature for super admin content

### DIFF
--- a/scripts/migration-desk-feature.sql
+++ b/scripts/migration-desk-feature.sql
@@ -1,0 +1,35 @@
+-- =====================================================
+-- MIGRATION: "From the Desk" Feature
+-- Adds super_admin role and post type field
+-- =====================================================
+
+-- 1. Add super_admin to users role constraint
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check
+  CHECK (role IN ('super_admin', 'admin', 'writer'));
+
+-- 2. Add type field to posts table
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'post';
+
+-- 3. Add check constraint for post type
+ALTER TABLE posts DROP CONSTRAINT IF EXISTS posts_type_check;
+ALTER TABLE posts ADD CONSTRAINT posts_type_check
+  CHECK (type IN ('post', 'desk'));
+
+-- 4. Create index for post type
+CREATE INDEX IF NOT EXISTS idx_posts_type ON posts(type);
+
+-- 5. Promote super admin user (run manually with your admin email)
+-- UPDATE users SET role = 'super_admin' WHERE email = 'your-admin-email@example.com';
+
+-- =====================================================
+-- VERIFICATION QUERIES
+-- =====================================================
+
+-- Check role constraint
+-- SELECT constraint_name, check_clause FROM information_schema.check_constraints
+-- WHERE constraint_name = 'users_role_check';
+
+-- Check posts table has type column
+-- SELECT column_name, data_type, column_default FROM information_schema.columns
+-- WHERE table_name = 'posts' AND column_name = 'type';

--- a/scripts/setup-supabase.sql
+++ b/scripts/setup-supabase.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS users (
     avatar_url TEXT,
     website_url TEXT,
     social_links JSONB DEFAULT '{}',
-    role TEXT NOT NULL DEFAULT 'writer' CHECK (role IN ('admin', 'writer')),
+    role TEXT NOT NULL DEFAULT 'writer' CHECK (role IN ('super_admin', 'admin', 'writer')),
     status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'deleted')),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS posts (
     author_id UUID NOT NULL REFERENCES users(id),
     status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
     featured BOOLEAN DEFAULT FALSE,
-    allow_comments BOOLEAN DEFAULT TRUE
+    allow_comments BOOLEAN DEFAULT TRUE,
+    type TEXT NOT NULL DEFAULT 'post' CHECK (type IN ('post', 'desk'))
 );
 
 -- 4. COMMENTS TABLE
@@ -167,6 +168,7 @@ CREATE INDEX IF NOT EXISTS idx_posts_status ON posts(status);
 CREATE INDEX IF NOT EXISTS idx_posts_normalized_title ON posts(normalized_title);
 CREATE INDEX IF NOT EXISTS idx_posts_pub_date ON posts(pub_date DESC);
 CREATE INDEX IF NOT EXISTS idx_posts_category ON posts(category);
+CREATE INDEX IF NOT EXISTS idx_posts_type ON posts(type);
 
 CREATE INDEX IF NOT EXISTS idx_likes_post_id ON likes(post_id);
 CREATE INDEX IF NOT EXISTS idx_likes_user_id ON likes(user_id);

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -111,13 +111,24 @@ export async function POST(request: NextRequest) {
     // Check if user is authenticated
     const authUser = await getAuthUser()
 
+    // For authenticated users, get their display name
+    let finalAuthorName = author_name
+    if (authUser) {
+      const { data: user } = await supabase
+        .from('users')
+        .select('display_name')
+        .eq('id', authUser.userId)
+        .single()
+      finalAuthorName = user?.display_name || author_name
+    }
+
     const { data: comment, error } = await supabase
       .from('comments')
       .insert({
         post_id,
         content,
-        author_name: authUser ? undefined : author_name,
-        author_email: authUser ? undefined : author_email,
+        author_name: finalAuthorName,
+        author_email: authUser ? null : author_email,
         author_id: authUser?.userId || null,
         parent_id: parent_id || null,
         status: 'approved', // Auto-approve for now

--- a/src/app/api/desk/route.ts
+++ b/src/app/api/desk/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+
+// GET - List published desk posts (public)
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const page = parseInt(searchParams.get('page') || '1')
+    const limit = parseInt(searchParams.get('limit') || '10')
+    const offset = (page - 1) * limit
+
+    const supabase = createServerClient()
+
+    if (!supabase) {
+      return NextResponse.json({
+        success: true,
+        data: [],
+        pagination: { page, limit, total: 0, totalPages: 0 },
+        message: 'Database not configured'
+      })
+    }
+
+    const { data: posts, error, count } = await supabase
+      .from('posts')
+      .select(`
+        *,
+        author:users!posts_author_id_fkey(id, username, display_name, avatar_url, bio)
+      `, { count: 'exact' })
+      .eq('status', 'published')
+      .eq('type', 'desk')
+      .order('pub_date', { ascending: false })
+      .range(offset, offset + limit - 1)
+
+    if (error) {
+      console.error('Fetch desk posts error:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch desk posts' },
+        { status: 500 }
+      )
+    }
+
+    const response = NextResponse.json({
+      success: true,
+      data: posts,
+      pagination: {
+        page,
+        limit,
+        total: count || 0,
+        totalPages: Math.ceil((count || 0) / limit),
+      },
+    })
+
+    // Cache public desk posts list for 60 seconds on Vercel edge
+    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300')
+    return response
+  } catch (error) {
+    console.error('Fetch desk posts error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/posts/my/route.ts
+++ b/src/app/api/posts/my/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@/lib/supabase'
-import { getAuthUser } from '@/lib/auth'
+import { getAuthUser, isSuperAdmin } from '@/lib/auth'
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,6 +12,9 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    const { searchParams } = new URL(request.url)
+    const type = searchParams.get('type') || 'post'
+
     const supabase = createServerClient()
 
     if (!supabase) {
@@ -21,11 +24,58 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const { data: posts, error } = await supabase
+    // For desk posts, verify super admin
+    if (type === 'desk') {
+      const { data: fullUser } = await supabase
+        .from('users')
+        .select('role, email')
+        .eq('id', authUser.userId)
+        .single()
+
+      if (!isSuperAdmin(fullUser)) {
+        return NextResponse.json(
+          { success: false, error: 'Only super admin can access desk posts' },
+          { status: 403 }
+        )
+      }
+    }
+
+    let query = supabase
       .from('posts')
       .select('*')
-      .eq('author_id', authUser.userId)
       .order('updated_at', { ascending: false })
+
+    // Regular posts: filter by author, desk posts: all (super admin only)
+    if (type === 'post') {
+      query = query.eq('author_id', authUser.userId)
+    }
+
+    // Try with type filter, fall back without it if column doesn't exist
+    let posts
+    let error
+
+    if (type === 'desk') {
+      // For desk posts, must have type column
+      const result = await query.eq('type', 'desk')
+      posts = result.data
+      error = result.error
+    } else {
+      // For regular posts, try type filter first
+      const result = await query.or('type.eq.post,type.is.null')
+      posts = result.data
+      error = result.error
+
+      // If error (column doesn't exist), retry without type filter
+      if (error) {
+        const fallback = await supabase
+          .from('posts')
+          .select('*')
+          .eq('author_id', authUser.userId)
+          .order('updated_at', { ascending: false })
+        posts = fallback.data
+        error = fallback.error
+      }
+    }
 
     if (error) {
       console.error('Fetch my posts error:', error)

--- a/src/app/dashboard/desk/new/page.tsx
+++ b/src/app/dashboard/desk/new/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { PostEditor } from '@/components/posts/PostEditor'
+import { PostFormData } from '@/types'
+
+export default function NewDeskPostPage() {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasAccess, setHasAccess] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    // Check if user has super admin access
+    const checkAccess = async () => {
+      try {
+        const response = await fetch('/api/posts/my?type=desk')
+        if (response.status === 403) {
+          router.push('/dashboard')
+        } else {
+          setHasAccess(true)
+        }
+      } catch {
+        router.push('/dashboard')
+      }
+    }
+    checkAccess()
+  }, [router])
+
+  const handleSave = async (data: PostFormData) => {
+    setIsLoading(true)
+    try {
+      const response = await fetch('/api/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, type: 'desk' }),
+      })
+
+      const result = await response.json()
+
+      if (result.success) {
+        router.push('/dashboard/desk')
+      } else {
+        alert(result.error || 'Failed to create desk post')
+      }
+    } catch {
+      alert('Network error')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (hasAccess === null) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
+      </div>
+    )
+  }
+
+  return <PostEditor onSave={handleSave} isLoading={isLoading} isDeskPost />
+}

--- a/src/app/dashboard/desk/page.tsx
+++ b/src/app/dashboard/desk/page.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { Post } from '@/types'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { NotebookPen, Eye, Edit2, Trash2, Plus } from 'lucide-react'
+
+export default function DeskDashboardPage() {
+  const { user } = useAuth()
+  const router = useRouter()
+  const [posts, setPosts] = useState<Post[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<'all' | 'published' | 'draft'>('all')
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const response = await fetch('/api/posts/my?type=desk')
+        const data = await response.json()
+        if (data.success) {
+          setPosts(data.data)
+        } else if (response.status === 403) {
+          setError('You do not have permission to access this page')
+          router.push('/dashboard')
+        }
+      } catch (error) {
+        console.error('Failed to fetch desk posts:', error)
+        setError('Failed to load desk posts')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchPosts()
+  }, [router])
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Are you sure you want to delete this desk post?')) return
+
+    try {
+      const response = await fetch(`/api/posts/${id}`, { method: 'DELETE' })
+      if (response.ok) {
+        setPosts((prev) => prev.filter((p) => p.id !== id))
+      }
+    } catch (error) {
+      console.error('Failed to delete post:', error)
+    }
+  }
+
+  const filteredPosts = posts.filter((post) => {
+    if (filter === 'all') return true
+    return post.status === filter
+  })
+
+  const publishedCount = posts.filter((p) => p.status === 'published').length
+  const draftCount = posts.filter((p) => p.status === 'draft').length
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[var(--color-error)]">{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-6 sm:mb-8">
+        <div>
+          <div className="flex items-center gap-2">
+            <NotebookPen className="w-6 h-6 text-[var(--color-link)]" />
+            <h1 className="text-xl sm:text-2xl font-bold text-[var(--color-text-primary)]">
+              From the Desk
+            </h1>
+          </div>
+          <p className="text-sm sm:text-base text-[var(--color-text-secondary)] mt-1">
+            Manage Inkhouse updates, guidelines, and announcements
+          </p>
+        </div>
+        <Link
+          href="/dashboard/desk/new"
+          className="btn-primary inline-flex items-center justify-center px-3 sm:px-4 py-2 rounded-md text-sm sm:text-base w-full sm:w-auto"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          New Desk Post
+        </Link>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 sm:gap-4 mb-8">
+        <div className="bg-[var(--color-bg-card)] rounded-lg p-3 sm:p-4 shadow-[var(--shadow-light)]">
+          <p className="text-xl sm:text-3xl font-bold text-[var(--color-text-primary)]">
+            {posts.length}
+          </p>
+          <p className="text-xs sm:text-base text-[var(--color-text-secondary)]">Total</p>
+        </div>
+        <div className="bg-[var(--color-bg-card)] rounded-lg p-3 sm:p-4 shadow-[var(--shadow-light)]">
+          <p className="text-xl sm:text-3xl font-bold text-[var(--color-success)]">{publishedCount}</p>
+          <p className="text-xs sm:text-base text-[var(--color-text-secondary)]">Published</p>
+        </div>
+        <div className="bg-[var(--color-bg-card)] rounded-lg p-3 sm:p-4 shadow-[var(--shadow-light)]">
+          <p className="text-xl sm:text-3xl font-bold text-[var(--color-warning)]">{draftCount}</p>
+          <p className="text-xs sm:text-base text-[var(--color-text-secondary)]">Drafts</p>
+        </div>
+      </div>
+
+      {/* Filter */}
+      <div className="flex space-x-2 mb-6 overflow-x-auto pb-2">
+        {(['all', 'published', 'draft'] as const).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium whitespace-nowrap ${
+              filter === f
+                ? 'btn-primary'
+                : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)]'
+            }`}
+          >
+            {f.charAt(0).toUpperCase() + f.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Posts list */}
+      {filteredPosts.length === 0 ? (
+        <div className="text-center py-12 bg-[var(--color-bg-card)] rounded-lg">
+          <NotebookPen className="w-12 h-12 mx-auto text-[var(--color-text-muted)] mb-4" />
+          <p className="text-[var(--color-text-muted)] mb-4">
+            {filter === 'all'
+              ? "No desk posts yet"
+              : `No ${filter} desk posts`}
+          </p>
+          <Link
+            href="/dashboard/desk/new"
+            className="text-[var(--color-link)] hover:text-[var(--color-link-hover)]"
+          >
+            Create your first desk post →
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-3 sm:space-y-4">
+          {filteredPosts.map((post) => (
+            <div
+              key={post.id}
+              className="bg-[var(--color-bg-card)] rounded-lg shadow-[var(--shadow-light)] p-3 sm:p-4"
+            >
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <NotebookPen className="w-4 h-4 text-[var(--color-link)] shrink-0" />
+                    <h3 className="font-medium text-[var(--color-text-primary)] text-sm sm:text-base truncate max-w-[200px] sm:max-w-none">
+                      {post.title}
+                    </h3>
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full shrink-0 ${
+                        post.status === 'published'
+                          ? 'bg-[var(--color-success-light)] text-[var(--color-success)]'
+                          : 'bg-[var(--color-warning-light)] text-[var(--color-warning)]'
+                      }`}
+                    >
+                      {post.status}
+                    </span>
+                  </div>
+                  {post.description && (
+                    <p className="text-xs sm:text-sm text-[var(--color-text-secondary)] mt-1 line-clamp-1">
+                      {post.description}
+                    </p>
+                  )}
+                  <p className="text-xs text-[var(--color-text-muted)] mt-1 sm:mt-2">
+                    {new Date(post.pub_date || post.updated_at).toLocaleDateString()}
+                    {post.category && ` · ${post.category}`}
+                  </p>
+                </div>
+                <div className="flex items-center space-x-1 sm:space-x-2 sm:ml-4">
+                  {post.status === 'published' && (
+                    <Link
+                      href={`/desk/${post.normalized_title}`}
+                      className="relative group p-1.5 sm:p-2 text-[var(--color-text-muted)] hover:text-[var(--color-link)]"
+                    >
+                      <Eye className="w-4 h-4 sm:w-5 sm:h-5" />
+                      <span className="hidden sm:block absolute -bottom-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+                        View
+                      </span>
+                    </Link>
+                  )}
+                  <Link
+                    href={`/dashboard/edit/${post.id}`}
+                    className="relative group p-1.5 sm:p-2 text-[var(--color-text-muted)] hover:text-[var(--color-link)]"
+                  >
+                    <Edit2 className="w-4 h-4 sm:w-5 sm:h-5" />
+                    <span className="hidden sm:block absolute -bottom-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+                      Edit
+                    </span>
+                  </Link>
+                  <button
+                    onClick={() => handleDelete(post.id)}
+                    className="relative group p-1.5 sm:p-2 text-[var(--color-error)] hover:opacity-80"
+                  >
+                    <Trash2 className="w-4 h-4 sm:w-5 sm:h-5" />
+                    <span className="hidden sm:block absolute -bottom-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+                      Delete
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/desk/[slug]/page.tsx
+++ b/src/app/desk/[slug]/page.tsx
@@ -1,0 +1,151 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Navbar } from '@/components/layout/Navbar'
+import { Calendar, ArrowLeft, NotebookPen } from 'lucide-react'
+import { createServerClient } from '@/lib/supabase'
+import parse from 'html-react-parser'
+import { CommentsSection } from '@/components/comments/CommentsSection'
+
+export const revalidate = 60
+
+async function getDeskPost(slug: string) {
+  const supabase = createServerClient()
+  if (!supabase) return null
+
+  const { data: post } = await supabase
+    .from('posts')
+    .select(`
+      *,
+      author:users!posts_author_id_fkey(id, username, display_name, avatar_url)
+    `)
+    .eq('normalized_title', slug)
+    .eq('status', 'published')
+    .eq('type', 'desk')
+    .single()
+
+  return post
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getDeskPost(slug)
+
+  if (!post) {
+    return { title: 'Post not found - Inkhouse' }
+  }
+
+  return {
+    title: `${post.title} - From the Desk - Inkhouse`,
+    description: post.description || post.title,
+    openGraph: {
+      title: post.title,
+      description: post.description || post.title,
+      images: post.image_url ? [post.image_url] : [],
+    },
+  }
+}
+
+export default async function DeskPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const post = await getDeskPost(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-secondary)]">
+      <Navbar />
+
+      <article className="max-w-3xl mx-auto px-4 py-8">
+        {/* Back link */}
+        <Link
+          href="/desk"
+          className="inline-flex items-center text-[var(--color-text-secondary)] hover:text-[#0D9488] mb-8"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to From the Desk
+        </Link>
+
+        {/* Header */}
+        <header className="mb-8">
+          <div className="flex items-center gap-2 mb-4">
+            <NotebookPen className="w-5 h-5 text-[var(--color-link)]" />
+            <span className="text-sm font-medium text-[var(--color-link)]">
+              From the Desk
+            </span>
+          </div>
+          {post.category && (
+            <span className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wide">
+              {post.category}
+            </span>
+          )}
+          <h1 className="text-4xl font-bold text-[var(--color-text-primary)] mt-2 mb-4">
+            {post.title}
+          </h1>
+          {post.description && (
+            <p className="text-xl text-[var(--color-text-secondary)]">
+              {post.description}
+            </p>
+          )}
+          <div className="flex items-center mt-6 text-[var(--color-text-muted)]">
+            <Calendar className="w-4 h-4 mr-2" />
+            {new Date(post.pub_date).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </div>
+        </header>
+
+        {/* Featured Image */}
+        {post.image_url && (
+          <div className="relative w-full mb-8 rounded-lg overflow-hidden">
+            <Image
+              src={post.image_url}
+              alt={post.title}
+              width={800}
+              height={400}
+              className="w-full h-auto object-cover rounded-lg"
+              priority
+            />
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="prose dark:prose-invert max-w-none mb-12">
+          {parse(post.content.replace(/&nbsp;/g, ' '))}
+        </div>
+
+        {/* From Inkhouse */}
+        <div className="border-t border-[var(--color-border-light)] pt-8">
+          <div className="flex items-center space-x-4">
+            <div className="w-16 h-16 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center">
+              <NotebookPen className="w-8 h-8 text-[var(--color-link)]" />
+            </div>
+            <div>
+              <p className="text-lg font-medium text-[var(--color-text-primary)]">
+                Inkhouse
+              </p>
+              <p className="text-sm text-[var(--color-text-muted)]">
+                Updates and stories from the Inkhouse team
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Comments */}
+        <CommentsSection postId={post.id} allowComments={post.allow_comments !== false} />
+      </article>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--color-border-light)] mt-12 py-8">
+        <div className="max-w-6xl mx-auto px-4 text-center text-[var(--color-text-muted)]">
+          <p>Inkhouse - A home for writers</p>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/app/desk/page.tsx
+++ b/src/app/desk/page.tsx
@@ -1,0 +1,138 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { Navbar } from '@/components/layout/Navbar'
+import { createServerClient } from '@/lib/supabase'
+import { formatDistanceToNow } from 'date-fns'
+import { NotebookPen } from 'lucide-react'
+
+export const revalidate = 60
+
+export const metadata: Metadata = {
+  title: 'From the Desk - Inkhouse',
+  description: 'Updates, guidelines, and stories from the Inkhouse team.',
+  openGraph: {
+    title: 'From the Desk - Inkhouse',
+    description: 'Updates, guidelines, and stories from the Inkhouse team.',
+  },
+}
+
+async function getDeskPosts() {
+  const supabase = createServerClient()
+  if (!supabase) {
+    return { posts: [], totalPages: 0 }
+  }
+
+  const { data: posts, count } = await supabase
+    .from('posts')
+    .select(`
+      *,
+      author:users!posts_author_id_fkey(id, username, display_name, avatar_url)
+    `, { count: 'exact' })
+    .eq('status', 'published')
+    .eq('type', 'desk')
+    .order('pub_date', { ascending: false })
+    .range(0, 19)
+
+  return {
+    posts: posts || [],
+    totalPages: Math.ceil((count || 0) / 20),
+  }
+}
+
+function getReadingTime(content: string): number {
+  const wordsPerMinute = 200
+  const words = content.replace(/<[^>]*>/g, '').split(/\s+/).length
+  return Math.ceil(words / wordsPerMinute)
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '').trim()
+}
+
+export default async function DeskPage() {
+  const { posts } = await getDeskPosts()
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-tertiary)]">
+      <Navbar />
+
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        {/* Hero */}
+        <div className="text-center mb-12">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[var(--color-bg-card)] border border-[var(--color-border-light)] mb-4">
+            <NotebookPen className="w-8 h-8 text-[var(--color-link)]" />
+          </div>
+          <h1 className="text-4xl font-bold text-[var(--color-text-primary)] mb-4">
+            From the Desk
+          </h1>
+          <p className="text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+            Updates, guidelines, philosophy, and stories from Inkhouse.
+          </p>
+        </div>
+
+        {/* Posts */}
+        {posts.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-[var(--color-text-muted)]">
+              No posts yet. Check back soon!
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {posts.map((post, index) => {
+              const readingTime = getReadingTime(post.content)
+              const excerpt = post.description || stripHtml(post.content).substring(0, 200) + '...'
+              const isLatest = index === 0
+
+              return (
+                <Link
+                  key={post.id}
+                  href={`/desk/${post.normalized_title}`}
+                  className={`block bg-[var(--color-bg-card)] rounded-lg border border-[var(--color-border-light)] hover:border-[var(--color-border-medium)] transition-colors ${
+                    isLatest ? 'p-8' : 'p-6'
+                  }`}
+                >
+                  {isLatest && (
+                    <span className="inline-block text-xs font-medium text-[var(--color-link)] bg-[var(--color-bg-tertiary)] px-2 py-1 rounded mb-3">
+                      Latest
+                    </span>
+                  )}
+                  <h2 className={`font-bold text-[var(--color-text-primary)] mb-2 ${
+                    isLatest ? 'text-2xl' : 'text-xl'
+                  }`}>
+                    {post.title}
+                  </h2>
+                  <p className={`text-[var(--color-text-secondary)] mb-4 ${
+                    isLatest ? 'text-base' : 'text-sm'
+                  }`}>
+                    {excerpt}
+                  </p>
+                  <div className="flex items-center text-sm text-[var(--color-text-muted)]">
+                    <span>
+                      {formatDistanceToNow(new Date(post.pub_date), { addSuffix: true })}
+                    </span>
+                    <span className="mx-2">·</span>
+                    <span>{readingTime} min read</span>
+                    {post.category && (
+                      <>
+                        <span className="mx-2">·</span>
+                        <span>{post.category}</span>
+                      </>
+                    )}
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--color-border-light)] mt-12 py-8">
+        <div className="max-w-6xl mx-auto px-4 text-center text-[var(--color-text-muted)]">
+          <p>Inkhouse - A home for writers</p>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -125,13 +125,15 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
             <div className="flex items-start space-x-4">
               <Link href={`/author/${post.author.username}`}>
                 {post.author.avatar_url ? (
-                  <Image
-                    src={post.author.avatar_url}
-                    alt={post.author.display_name}
-                    width={64}
-                    height={64}
-                    className="rounded-full"
-                  />
+                  <div className="w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
+                    <Image
+                      src={post.author.avatar_url}
+                      alt={post.author.display_name}
+                      width={64}
+                      height={64}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
                 ) : (
                   <div className="w-16 h-16 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center">
                     <User className="w-8 h-8 text-[#0D9488]" />

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import Image from 'next/image'
-import { PenLine, FileText, User, LogOut, Home, Users, Settings, Menu, X, Key } from 'lucide-react'
+import { PenLine, FileText, User, LogOut, Home, Users, Settings, Menu, X, Key, NotebookPen } from 'lucide-react'
 import ThemeToggle from '@/components/common/ThemeToggle'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
 
@@ -24,7 +24,8 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [showApiKeysTooltip, setShowApiKeysTooltip] = useState(false)
 
-  const isAdmin = user?.role === 'admin'
+  const isAdmin = user?.role === 'admin' || user?.role === 'super_admin'
+  const isSuperAdmin = user?.role === 'super_admin'
 
   // Close sidebar on route change (mobile)
   useEffect(() => {
@@ -51,6 +52,10 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     { href: '/admin/requests', label: 'Requests', icon: Users },
     { href: '/admin/members', label: 'Members', icon: Users },
     { href: '/admin/posts', label: 'All Posts', icon: FileText },
+  ]
+
+  const superAdminLinks = [
+    { href: '/dashboard/desk', label: 'From the Desk', icon: NotebookPen },
   ]
 
   const handleLogoutClick = () => {
@@ -194,6 +199,28 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                 </Link>
               ))}
             </div>
+
+            {isSuperAdmin && (
+              <div className="pt-4">
+                <p className="px-3 text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider">
+                  Super Admin
+                </p>
+                {superAdminLinks.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className={`flex items-center space-x-3 px-3 py-2 rounded-md mt-1 ${
+                      pathname === link.href || pathname.startsWith(link.href + '/')
+                        ? 'bg-[var(--color-bg-tertiary)] text-[var(--color-link)]'
+                        : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)]'
+                    }`}
+                  >
+                    <link.icon className="w-5 h-5" />
+                    <span>{link.label}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
 
             {isAdmin && (
               <div className="pt-4">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -5,7 +5,7 @@ import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useAuth } from '@/contexts/AuthContext'
-import { PenLine, LogIn, User, X } from 'lucide-react'
+import { PenLine, LogIn, User, X, NotebookPen } from 'lucide-react'
 import ThemeToggle from '@/components/common/ThemeToggle'
 
 export function Navbar() {
@@ -54,6 +54,17 @@ export function Navbar() {
         </Link>
 
         <nav className="flex items-center space-x-4">
+          <Link
+            href="/desk"
+            className="hidden sm:flex items-center px-3 py-1.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors relative group"
+          >
+            <NotebookPen className="w-4 h-4 mr-1.5 text-[var(--color-link)]" />
+            <span className="font-medium">Desk</span>
+            <span className="absolute -bottom-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs bg-[var(--color-bg-card)] border border-[var(--color-border-light)] text-[var(--color-text-primary)] rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap shadow-md">
+              Behind the ink
+            </span>
+          </Link>
+
           <ThemeToggle />
 
           {!isLoading && (

--- a/src/components/posts/PostEditor.tsx
+++ b/src/components/posts/PostEditor.tsx
@@ -34,11 +34,12 @@ interface PostEditorProps {
   post?: Post
   onSave: (data: PostFormData) => Promise<void>
   isLoading?: boolean
+  isDeskPost?: boolean
 }
 
 const DRAFT_KEY = 'inkhouse-draft'
 
-export function PostEditor({ post, onSave, isLoading }: PostEditorProps) {
+export function PostEditor({ post, onSave, isLoading, isDeskPost }: PostEditorProps) {
   const [quillEditor, setQuillEditor] = useState<any>(null)
   const { theme } = useTheme()
   const [isDrawingOpen, setIsDrawingOpen] = useState(false)
@@ -229,7 +230,7 @@ export function PostEditor({ post, onSave, isLoading }: PostEditorProps) {
       {/* Header - Compact */}
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-3">
         <h1 className="text-lg sm:text-xl font-bold text-[var(--color-text-primary)]">
-          {post ? 'Edit Post' : 'New Post'}
+          {post ? (isDeskPost ? 'Edit Desk Post' : 'Edit Post') : (isDeskPost ? 'New Desk Post' : 'New Post')}
         </h1>
         <div className="flex items-center space-x-2">
           {lastSaved && !post && (

--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -198,13 +198,15 @@ export function PostGrid({ initialPosts, initialTotalPages, categories }: PostGr
                     className="flex items-center hover:text-[#0D9488]"
                   >
                     {post.author?.avatar_url ? (
-                      <Image
-                        src={post.author.avatar_url}
-                        alt={post.author.display_name}
-                        width={24}
-                        height={24}
-                        className="rounded-full mr-2"
-                      />
+                      <div className="w-6 h-6 rounded-full overflow-hidden mr-2 flex-shrink-0">
+                        <Image
+                          src={post.author.avatar_url}
+                          alt={post.author.display_name}
+                          width={24}
+                          height={24}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
                     ) : (
                       <User className="w-5 h-5 mr-2" />
                     )}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -88,3 +88,29 @@ export function generateTempPassword(): string {
   }
   return password
 }
+
+/**
+ * Check if a user is super admin
+ * Verifies both role in DB and email matches SUPER_ADMIN_EMAIL env variable
+ */
+export function isSuperAdmin(user: { role: string; email: string } | null): boolean {
+  if (!user) return false
+
+  const superAdminEmail = process.env.SUPER_ADMIN_EMAIL
+
+  // Must have super_admin role AND email must match env variable (if set)
+  if (user.role !== 'super_admin') return false
+
+  // If SUPER_ADMIN_EMAIL is set, verify email matches
+  if (superAdminEmail && user.email !== superAdminEmail) return false
+
+  return true
+}
+
+/**
+ * Check if user has admin-level access (super_admin or admin)
+ */
+export function isAdmin(user: { role: string } | null): boolean {
+  if (!user) return false
+  return user.role === 'super_admin' || user.role === 'admin'
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export interface User {
   avatar_url?: string
   website_url?: string
   social_links?: Record<string, string>
-  role: 'admin' | 'writer'
+  role: 'super_admin' | 'admin' | 'writer'
   status: 'active' | 'suspended' | 'deleted'
   created_at: string
   updated_at: string
@@ -51,6 +51,7 @@ export interface Post {
   status: 'draft' | 'published' | 'archived'
   featured: boolean
   allow_comments: boolean
+  type: 'post' | 'desk'
 }
 
 export interface PostWithAuthor extends Post {
@@ -216,6 +217,7 @@ export interface PostFormData {
   status: 'draft' | 'published' | 'archived'
   featured?: boolean
   allow_comments?: boolean
+  type?: 'post' | 'desk'
 }
 
 export interface ProfileFormData {
@@ -245,11 +247,11 @@ export interface JWTPayload {
   userId: string
   email: string
   username: string
-  role: 'admin' | 'writer'
+  role: 'super_admin' | 'admin' | 'writer'
 }
 
 // Component Props
 export interface AuthGuardProps {
   children: React.ReactNode
-  requiredRole?: 'admin' | 'writer'
+  requiredRole?: 'super_admin' | 'admin' | 'writer'
 }


### PR DESCRIPTION
## Summary
- Add super_admin role and post type (post/desk) to database schema
- Create `/desk` public page for viewing desk posts with "Behind the ink" tooltip
- Create `/desk/[slug]` page for individual desk posts
- Add dashboard desk management (`/dashboard/desk`) for super admin
- Add `isSuperAdmin` and `isAdmin` helpers to auth.ts
- Update posts API to filter by type with fallback for missing column
- Fix authenticated user comments (author_name null issue)
- Fix avatar circular styling on homepage and post pages

## New Routes
- `/desk` - Public desk posts listing
- `/desk/[slug]` - Individual desk post view
- `/dashboard/desk` - Super admin desk management
- `/dashboard/desk/new` - Create new desk post
- `/api/desk` - Desk posts API

## Database Migration Required
Run `scripts/migration-desk-feature.sql` or:
```sql
-- Update users role constraint
ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check;
ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('super_admin', 'admin', 'writer'));

-- Promote super admin
UPDATE users SET role = 'super_admin' WHERE email = 'YOUR_EMAIL';

-- Add type column to posts
ALTER TABLE posts ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'post';
ALTER TABLE posts ADD CONSTRAINT posts_type_check CHECK (type IN ('post', 'desk'));
CREATE INDEX IF NOT EXISTS idx_posts_type ON posts(type);
```

## Test plan
- [x] Run database migration
- [x] Verify homepage still shows posts
- [x] Verify `/desk` page loads (empty initially)
- [x] Promote user to super_admin and verify dashboard shows "From the Desk" link
- [x] Create a desk post and verify it appears on `/desk`
- [x] Verify desk posts don't appear on homepage