### PR TITLE
fix: Simplify super admin check and fix type error

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ interface AuthContextType {
   isAuthenticated: boolean
   login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>
   logout: () => Promise<void>
-  refreshUser: () => Promise<void>
+  refreshUser: () => Promise<boolean>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -155,7 +155,7 @@ export function useAuth() {
       isAuthenticated: false,
       login: async () => ({ success: false, error: 'Not initialized' }),
       logout: async () => {},
-      refreshUser: async () => {},
+      refreshUser: async () => false,
     }
   }
   return context

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -90,21 +90,11 @@ export function generateTempPassword(): string {
 }
 
 /**
- * Check if a user is super admin
- * Verifies both role in DB and email matches SUPER_ADMIN_EMAIL env variable
+ * Check if a user is super admin based on database role
  */
-export function isSuperAdmin(user: { role: string; email: string } | null): boolean {
+export function isSuperAdmin(user: { role: string } | null): boolean {
   if (!user) return false
-
-  const superAdminEmail = process.env.SUPER_ADMIN_EMAIL
-
-  // Must have super_admin role AND email must match env variable (if set)
-  if (user.role !== 'super_admin') return false
-
-  // If SUPER_ADMIN_EMAIL is set, verify email matches
-  if (superAdminEmail && user.email !== superAdminEmail) return false
-
-  return true
+  return user.role === 'super_admin'
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove email verification from isSuperAdmin - now only checks database role
- Fix refreshUser return type in AuthContext (boolean instead of void)

Fixes "From the Desk" permission error on server.