### PR TITLE
feat: Add Google OAuth login

### DIFF
--- a/scripts/migration-google-oauth.sql
+++ b/scripts/migration-google-oauth.sql
@@ -1,0 +1,34 @@
+-- Migration: Add Google OAuth support
+-- Run this in Supabase SQL Editor
+
+-- Add Google OAuth fields to users table
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS google_id TEXT UNIQUE,
+ADD COLUMN IF NOT EXISTS auth_provider TEXT DEFAULT 'local';
+
+-- Add check constraint for auth_provider (if not exists)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_auth_provider_check'
+  ) THEN
+    ALTER TABLE users ADD CONSTRAINT users_auth_provider_check
+      CHECK (auth_provider IN ('local', 'google', 'both'));
+  END IF;
+END $$;
+
+-- Index for Google ID lookups
+CREATE INDEX IF NOT EXISTS idx_users_google_id ON users(google_id);
+
+-- Update existing users to 'local' provider
+UPDATE users SET auth_provider = 'local' WHERE auth_provider IS NULL;
+
+-- Add Google OAuth fields to membership_requests (for writer requests via Google)
+ALTER TABLE membership_requests
+ADD COLUMN IF NOT EXISTS google_id TEXT,
+ADD COLUMN IF NOT EXISTS google_avatar_url TEXT;
+
+-- Verify the changes
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'users' AND column_name IN ('google_id', 'auth_provider');

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -1,0 +1,338 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  setAuthCookies,
+} from '@/lib/auth'
+import { sendNewReaderNotification, sendNewRequestNotification } from '@/lib/email'
+import { JWTPayload } from '@/types'
+import crypto from 'crypto'
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET
+const GOOGLE_REDIRECT_URI = `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/auth/google/callback`
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+
+interface GoogleTokenResponse {
+  access_token: string
+  id_token: string
+  expires_in: number
+  token_type: string
+  scope: string
+  refresh_token?: string
+}
+
+interface GoogleUserInfo {
+  id: string
+  email: string
+  verified_email: boolean
+  name: string
+  given_name?: string
+  family_name?: string
+  picture?: string
+}
+
+// Generate unique username from email prefix
+async function generateUniqueUsername(email: string, supabase: ReturnType<typeof createServerClient>): Promise<string> {
+  const baseUsername = email.split('@')[0].toLowerCase().replace(/[^a-z0-9_]/g, '')
+  let username = baseUsername.slice(0, 20) // Max 20 chars
+  let suffix = 0
+
+  while (true) {
+    const candidateUsername = suffix === 0 ? username : `${username.slice(0, 17)}${suffix}`
+    const { data: existing } = await supabase!
+      .from('users')
+      .select('id')
+      .eq('username', candidateUsername)
+      .single()
+
+    if (!existing) {
+      return candidateUsername
+    }
+    suffix++
+    if (suffix > 999) {
+      // Fallback to random suffix
+      return `${username.slice(0, 12)}${crypto.randomBytes(4).toString('hex')}`
+    }
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+  const error = searchParams.get('error')
+
+  // Handle Google OAuth errors
+  if (error) {
+    console.error('Google OAuth error:', error)
+    return NextResponse.redirect(`${APP_URL}/login?error=google_auth_failed`)
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(`${APP_URL}/login?error=missing_params`)
+  }
+
+  // Verify state matches cookie
+  const storedState = request.cookies.get('google_oauth_state')?.value
+  if (!storedState || storedState !== state) {
+    return NextResponse.redirect(`${APP_URL}/login?error=invalid_state`)
+  }
+
+  // Decode state to get source
+  let stateData: { token: string; source: string; timestamp: number }
+  try {
+    stateData = JSON.parse(Buffer.from(state, 'base64url').toString())
+  } catch {
+    return NextResponse.redirect(`${APP_URL}/login?error=invalid_state`)
+  }
+
+  // Check state hasn't expired (10 minutes)
+  if (Date.now() - stateData.timestamp > 10 * 60 * 1000) {
+    return NextResponse.redirect(`${APP_URL}/login?error=state_expired`)
+  }
+
+  const source = stateData.source // 'login', 'signup', or 'join'
+
+  // Exchange code for tokens
+  let tokens: GoogleTokenResponse
+  try {
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: GOOGLE_CLIENT_ID!,
+        client_secret: GOOGLE_CLIENT_SECRET!,
+        redirect_uri: GOOGLE_REDIRECT_URI,
+        grant_type: 'authorization_code',
+      }),
+    })
+
+    if (!tokenResponse.ok) {
+      console.error('Token exchange failed:', await tokenResponse.text())
+      return NextResponse.redirect(`${APP_URL}/login?error=token_exchange_failed`)
+    }
+
+    tokens = await tokenResponse.json()
+  } catch (err) {
+    console.error('Token exchange error:', err)
+    return NextResponse.redirect(`${APP_URL}/login?error=token_exchange_failed`)
+  }
+
+  // Get user info from Google
+  let googleUser: GoogleUserInfo
+  try {
+    const userResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    })
+
+    if (!userResponse.ok) {
+      console.error('User info fetch failed:', await userResponse.text())
+      return NextResponse.redirect(`${APP_URL}/login?error=user_info_failed`)
+    }
+
+    googleUser = await userResponse.json()
+  } catch (err) {
+    console.error('User info error:', err)
+    return NextResponse.redirect(`${APP_URL}/login?error=user_info_failed`)
+  }
+
+  // Ensure email is verified
+  if (!googleUser.verified_email) {
+    return NextResponse.redirect(`${APP_URL}/login?error=email_not_verified`)
+  }
+
+  const supabase = createServerClient()
+  if (!supabase) {
+    return NextResponse.redirect(`${APP_URL}/login?error=database_error`)
+  }
+
+  // Check if user exists by google_id
+  const { data: existingByGoogleId } = await supabase
+    .from('users')
+    .select('*')
+    .eq('google_id', googleUser.id)
+    .single()
+
+  if (existingByGoogleId) {
+    // Flow 4: Returning Google User - just log them in
+    return await loginUser(existingByGoogleId, request)
+  }
+
+  // Check if user exists by email
+  const { data: existingByEmail } = await supabase
+    .from('users')
+    .select('*')
+    .eq('email', googleUser.email.toLowerCase())
+    .single()
+
+  if (existingByEmail) {
+    // Flow 3: Existing user, first Google sign in - link accounts
+    await supabase
+      .from('users')
+      .update({
+        google_id: googleUser.id,
+        auth_provider: existingByEmail.password_hash ? 'both' : 'google',
+        avatar_url: existingByEmail.avatar_url || googleUser.picture,
+      })
+      .eq('id', existingByEmail.id)
+
+    return await loginUser({ ...existingByEmail, google_id: googleUser.id }, request)
+  }
+
+  // User doesn't exist - handle based on source
+  if (source === 'signup') {
+    // Flow 1: New reader via /signup
+    const username = await generateUniqueUsername(googleUser.email, supabase)
+
+    const { data: newUser, error: createError } = await supabase
+      .from('users')
+      .insert({
+        email: googleUser.email.toLowerCase(),
+        username,
+        display_name: googleUser.name,
+        avatar_url: googleUser.picture,
+        google_id: googleUser.id,
+        auth_provider: 'google',
+        role: 'reader',
+        status: 'active',
+      })
+      .select()
+      .single()
+
+    if (createError || !newUser) {
+      console.error('User creation error:', createError)
+      return NextResponse.redirect(`${APP_URL}/signup?error=account_creation_failed`)
+    }
+
+    // Create default preferences
+    await supabase.from('user_preferences').insert({
+      user_id: newUser.id,
+      view_mode: 'grid',
+      default_sort: 'date',
+    })
+
+    // Notify admin (non-blocking)
+    sendNewReaderNotification({
+      name: newUser.display_name,
+      username: newUser.username,
+      email: newUser.email,
+    }).catch(err => console.error('Failed to send notification:', err))
+
+    return await loginUser(newUser, request, '/?welcome=true')
+  }
+
+  if (source === 'join') {
+    // Flow 2: New writer request via /join
+    // Check if there's already a pending request
+    const { data: existingRequest } = await supabase
+      .from('membership_requests')
+      .select('id, status')
+      .eq('email', googleUser.email.toLowerCase())
+      .single()
+
+    if (existingRequest) {
+      if (existingRequest.status === 'pending') {
+        return NextResponse.redirect(`${APP_URL}/join?message=request_pending`)
+      }
+      if (existingRequest.status === 'rejected') {
+        return NextResponse.redirect(`${APP_URL}/join?message=request_rejected`)
+      }
+    }
+
+    // Create membership request
+    const username = googleUser.email.split('@')[0].toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0, 20)
+
+    const { error: requestError } = await supabase
+      .from('membership_requests')
+      .insert({
+        email: googleUser.email.toLowerCase(),
+        name: googleUser.name,
+        username,
+        writing_sample: '(Signed up via Google - no writing sample provided)',
+        google_id: googleUser.id,
+        google_avatar_url: googleUser.picture,
+        status: 'pending',
+      })
+
+    if (requestError) {
+      console.error('Membership request error:', requestError)
+      return NextResponse.redirect(`${APP_URL}/join?error=request_failed`)
+    }
+
+    // Notify admin
+    sendNewRequestNotification({
+      name: googleUser.name,
+      username,
+      email: googleUser.email,
+      writingSample: '(Signed up via Google)',
+    }).catch(err => console.error('Failed to send notification:', err))
+
+    return NextResponse.redirect(`${APP_URL}/join?success=true`)
+  }
+
+  // source === 'login' but no account exists
+  // Flow 5: Redirect to choose-role page
+  // Store Google user info in a temporary token
+  const tempData = {
+    googleId: googleUser.id,
+    email: googleUser.email,
+    name: googleUser.name,
+    picture: googleUser.picture,
+    timestamp: Date.now(),
+  }
+  const tempToken = Buffer.from(JSON.stringify(tempData)).toString('base64url')
+
+  const response = NextResponse.redirect(`${APP_URL}/auth/google/choose-role?token=${tempToken}`)
+
+  // Clear the OAuth state cookie
+  response.cookies.delete('google_oauth_state')
+
+  return response
+}
+
+async function loginUser(
+  user: { id: string; email: string; username: string; role: string },
+  request: NextRequest,
+  redirectPath = '/?welcome=true'
+) {
+  const supabase = createServerClient()!
+
+  // Generate tokens
+  const payload: JWTPayload = {
+    userId: user.id,
+    email: user.email,
+    username: user.username,
+    role: user.role as JWTPayload['role'],
+  }
+
+  const accessToken = generateAccessToken(payload)
+  const refreshToken = generateRefreshToken(payload)
+
+  // Store session
+  await supabase.from('sessions').insert({
+    user_id: user.id,
+    refresh_token: refreshToken,
+    expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    user_agent: request.headers.get('user-agent') || '',
+    ip_address: request.headers.get('x-forwarded-for') || '',
+  })
+
+  // Update last login
+  await supabase
+    .from('users')
+    .update({ last_login_at: new Date().toISOString() })
+    .eq('id', user.id)
+
+  // Set cookies and redirect
+  await setAuthCookies(accessToken, refreshToken)
+
+  const response = NextResponse.redirect(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}${redirectPath}`)
+
+  // Clear the OAuth state cookie
+  response.cookies.delete('google_oauth_state')
+
+  return response
+}

--- a/src/app/api/auth/google/complete/route.ts
+++ b/src/app/api/auth/google/complete/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  setAuthCookies,
+} from '@/lib/auth'
+import { sendNewReaderNotification, sendNewRequestNotification } from '@/lib/email'
+import { JWTPayload } from '@/types'
+import crypto from 'crypto'
+
+interface GoogleUserData {
+  googleId: string
+  email: string
+  name: string
+  picture?: string
+  timestamp: number
+}
+
+// Generate unique username from email prefix
+async function generateUniqueUsername(email: string, supabase: ReturnType<typeof createServerClient>): Promise<string> {
+  const baseUsername = email.split('@')[0].toLowerCase().replace(/[^a-z0-9_]/g, '')
+  let username = baseUsername.slice(0, 20)
+  let suffix = 0
+
+  while (true) {
+    const candidateUsername = suffix === 0 ? username : `${username.slice(0, 17)}${suffix}`
+    const { data: existing } = await supabase!
+      .from('users')
+      .select('id')
+      .eq('username', candidateUsername)
+      .single()
+
+    if (!existing) {
+      return candidateUsername
+    }
+    suffix++
+    if (suffix > 999) {
+      return `${username.slice(0, 12)}${crypto.randomBytes(4).toString('hex')}`
+    }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { token, wantsToWrite } = await request.json()
+
+    if (!token) {
+      return NextResponse.json(
+        { success: false, error: 'Missing token' },
+        { status: 400 }
+      )
+    }
+
+    // Decode and validate token
+    let userData: GoogleUserData
+    try {
+      userData = JSON.parse(Buffer.from(token, 'base64url').toString())
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid token' },
+        { status: 400 }
+      )
+    }
+
+    // Check if token is expired (10 minutes)
+    if (Date.now() - userData.timestamp > 10 * 60 * 1000) {
+      return NextResponse.json(
+        { success: false, error: 'Token expired' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Double-check user doesn't already exist
+    const { data: existingUser } = await supabase
+      .from('users')
+      .select('id')
+      .or(`email.eq.${userData.email.toLowerCase()},google_id.eq.${userData.googleId}`)
+      .single()
+
+    if (existingUser) {
+      return NextResponse.json(
+        { success: false, error: 'Account already exists. Please sign in instead.' },
+        { status: 400 }
+      )
+    }
+
+    // Create the user as reader
+    const username = await generateUniqueUsername(userData.email, supabase)
+
+    const { data: newUser, error: createError } = await supabase
+      .from('users')
+      .insert({
+        email: userData.email.toLowerCase(),
+        username,
+        display_name: userData.name,
+        avatar_url: userData.picture,
+        google_id: userData.googleId,
+        auth_provider: 'google',
+        role: 'reader',
+        status: 'active',
+      })
+      .select()
+      .single()
+
+    if (createError || !newUser) {
+      console.error('User creation error:', createError)
+      return NextResponse.json(
+        { success: false, error: 'Failed to create account' },
+        { status: 500 }
+      )
+    }
+
+    // Create default preferences
+    await supabase.from('user_preferences').insert({
+      user_id: newUser.id,
+      view_mode: 'grid',
+      default_sort: 'date',
+    })
+
+    // Notify admin about new reader
+    sendNewReaderNotification({
+      name: newUser.display_name,
+      username: newUser.username,
+      email: newUser.email,
+    }).catch(err => console.error('Failed to send notification:', err))
+
+    let writerRequestSubmitted = false
+
+    // If user wants to write, create a membership request for upgrade
+    if (wantsToWrite) {
+      const { error: requestError } = await supabase
+        .from('membership_requests')
+        .insert({
+          email: userData.email.toLowerCase(),
+          name: userData.name,
+          username,
+          writing_sample: '(Signed up via Google - requesting writer access)',
+          google_id: userData.googleId,
+          google_avatar_url: userData.picture,
+          status: 'pending',
+        })
+
+      if (!requestError) {
+        writerRequestSubmitted = true
+
+        // Notify admin about writer request
+        sendNewRequestNotification({
+          name: userData.name,
+          username,
+          email: userData.email,
+          writingSample: '(Signed up via Google - requesting writer access)',
+        }).catch(err => console.error('Failed to send notification:', err))
+      }
+    }
+
+    // Generate tokens and create session
+    const payload: JWTPayload = {
+      userId: newUser.id,
+      email: newUser.email,
+      username: newUser.username,
+      role: newUser.role,
+    }
+
+    const accessToken = generateAccessToken(payload)
+    const refreshToken = generateRefreshToken(payload)
+
+    // Store session
+    await supabase.from('sessions').insert({
+      user_id: newUser.id,
+      refresh_token: refreshToken,
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      user_agent: request.headers.get('user-agent') || '',
+      ip_address: request.headers.get('x-forwarded-for') || '',
+    })
+
+    // Set cookies
+    await setAuthCookies(accessToken, refreshToken)
+
+    return NextResponse.json({
+      success: true,
+      user: {
+        id: newUser.id,
+        email: newUser.email,
+        username: newUser.username,
+        display_name: newUser.display_name,
+        role: newUser.role,
+      },
+      writerRequestSubmitted,
+    })
+  } catch (error) {
+    console.error('Complete registration error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID
+const GOOGLE_REDIRECT_URI = `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/auth/google/callback`
+
+export async function GET(request: NextRequest) {
+  if (!GOOGLE_CLIENT_ID) {
+    return NextResponse.json(
+      { success: false, error: 'Google OAuth not configured' },
+      { status: 503 }
+    )
+  }
+
+  const searchParams = request.nextUrl.searchParams
+  const source = searchParams.get('source') || 'login' // 'login', 'signup', or 'join'
+
+  // Validate source
+  if (!['login', 'signup', 'join'].includes(source)) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid source parameter' },
+      { status: 400 }
+    )
+  }
+
+  // Generate state token for CSRF protection
+  // State includes: random token + source (to know which flow after callback)
+  const stateData = {
+    token: crypto.randomBytes(32).toString('hex'),
+    source,
+    timestamp: Date.now(),
+  }
+  const state = Buffer.from(JSON.stringify(stateData)).toString('base64url')
+
+  // Build Google OAuth URL
+  const googleAuthUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+  googleAuthUrl.searchParams.set('client_id', GOOGLE_CLIENT_ID)
+  googleAuthUrl.searchParams.set('redirect_uri', GOOGLE_REDIRECT_URI)
+  googleAuthUrl.searchParams.set('response_type', 'code')
+  googleAuthUrl.searchParams.set('scope', 'openid email profile')
+  googleAuthUrl.searchParams.set('state', state)
+  googleAuthUrl.searchParams.set('access_type', 'offline')
+  googleAuthUrl.searchParams.set('prompt', 'select_account')
+
+  // Store state in a short-lived cookie for verification in callback
+  const response = NextResponse.redirect(googleAuthUrl.toString())
+  response.cookies.set('google_oauth_state', state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 10, // 10 minutes
+    path: '/',
+  })
+
+  return response
+}

--- a/src/app/auth/google/choose-role/page.tsx
+++ b/src/app/auth/google/choose-role/page.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useState, useEffect, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { BookOpen, PenLine } from 'lucide-react'
+
+interface GoogleUserData {
+  googleId: string
+  email: string
+  name: string
+  picture?: string
+  timestamp: number
+}
+
+function ChooseRoleForm() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [userData, setUserData] = useState<GoogleUserData | null>(null)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token')
+
+  useEffect(() => {
+    if (!token) {
+      setError('Invalid or missing token')
+      return
+    }
+
+    try {
+      const data = JSON.parse(Buffer.from(token, 'base64url').toString()) as GoogleUserData
+
+      // Check if token is expired (10 minutes)
+      if (Date.now() - data.timestamp > 10 * 60 * 1000) {
+        setError('Session expired. Please try signing in again.')
+        return
+      }
+
+      setUserData(data)
+    } catch {
+      setError('Invalid token format')
+    }
+  }, [token])
+
+  const handleChooseRole = async (wantsToWrite: boolean) => {
+    if (!userData || !token) return
+
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const response = await fetch('/api/auth/google/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, wantsToWrite }),
+      })
+
+      const data = await response.json()
+
+      if (data.success) {
+        if (wantsToWrite && data.writerRequestSubmitted) {
+          router.push('/?welcome=true&writer_request=pending')
+        } else {
+          router.push('/?welcome=true')
+        }
+      } else {
+        setError(data.error || 'Something went wrong')
+      }
+    } catch {
+      setError('Failed to create account. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg-secondary)] py-12 px-4">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+            Inkhouse
+          </h1>
+          <div className="rounded-md bg-[var(--color-error-light)] p-4 mb-6">
+            <p className="text-sm text-[var(--color-error)]">{error}</p>
+          </div>
+          <Link
+            href="/login"
+            className="text-[var(--color-link)] hover:text-[var(--color-link-hover)]"
+          >
+            Back to login
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  if (!userData) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg-secondary)]">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg-secondary)] py-12 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
+            Inkhouse
+          </h1>
+          <h2 className="mt-6 text-2xl font-semibold text-[var(--color-text-primary)]">
+            Welcome, {userData.name}!
+          </h2>
+          <p className="mt-2 text-sm text-[var(--color-text-secondary)]">
+            No account found for {userData.email}. How would you like to join?
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <button
+            onClick={() => handleChooseRole(false)}
+            disabled={isLoading}
+            className="w-full flex items-center justify-between p-4 border-2 border-[var(--color-border-medium)] rounded-lg hover:border-[var(--color-link)] hover:bg-[var(--color-bg-hover)] transition-colors disabled:opacity-50"
+          >
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-[var(--color-bg-tertiary)]">
+                <BookOpen className="w-6 h-6 text-[var(--color-link)]" />
+              </div>
+              <div className="text-left">
+                <p className="font-medium text-[var(--color-text-primary)]">
+                  I want to Read
+                </p>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Track your reading, save favorites
+                </p>
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={() => handleChooseRole(true)}
+            disabled={isLoading}
+            className="w-full flex items-center justify-between p-4 border-2 border-[var(--color-border-medium)] rounded-lg hover:border-[var(--color-link)] hover:bg-[var(--color-bg-hover)] transition-colors disabled:opacity-50"
+          >
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-[var(--color-bg-tertiary)]">
+                <PenLine className="w-6 h-6 text-[var(--color-link)]" />
+              </div>
+              <div className="text-left">
+                <p className="font-medium text-[var(--color-text-primary)]">
+                  I want to Write
+                </p>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Start reading now, writer access after approval
+                </p>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        {isLoading && (
+          <div className="flex justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--color-button-primary)]"></div>
+          </div>
+        )}
+
+        <div className="text-center">
+          <Link
+            href="/login"
+            className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ChooseRolePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg-secondary)]">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
+        </div>
+      }
+    >
+      <ChooseRoleForm />
+    </Suspense>
+  )
+}

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -101,6 +101,32 @@ export default function JoinPage() {
           </p>
         </div>
 
+        <div className="bg-[var(--color-bg-card)] shadow-[var(--shadow-light)] rounded-lg p-6 space-y-6">
+          <div>
+            <a
+              href="/api/auth/google?source=join"
+              className="w-full flex items-center justify-center gap-3 py-2.5 px-4 border border-[var(--color-border-medium)] rounded-md bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors text-sm font-medium"
+            >
+              <span className="text-lg font-semibold">G</span>
+              Continue with Google
+            </a>
+            <p className="mt-2 text-xs text-center text-[var(--color-text-muted)]">
+              Quick sign up - we&apos;ll use your Google profile info
+            </p>
+          </div>
+
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-[var(--color-border-medium)]" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="bg-[var(--color-bg-card)] px-4 text-[var(--color-text-muted)]">
+                or fill out the form
+              </span>
+            </div>
+          </div>
+        </div>
+
         <form
           onSubmit={handleSubmit}
           className="bg-[var(--color-bg-card)] shadow-[var(--shadow-light)] rounded-lg p-6 space-y-6"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -66,18 +66,18 @@ export default function LoginPage() {
           </p>
         </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {sessionExpired && (
-            <div className="rounded-md bg-[var(--color-warning-light)] p-4">
-              <p className="text-sm text-[var(--color-warning)]">Your session has expired. Please sign in again.</p>
-            </div>
-          )}
-          {error && (
-            <div className="rounded-md bg-[var(--color-error-light)] p-4">
-              <p className="text-sm text-[var(--color-error)]">{error}</p>
-            </div>
-          )}
+        {sessionExpired && (
+          <div className="rounded-md bg-[var(--color-warning-light)] p-4">
+            <p className="text-sm text-[var(--color-warning)]">Your session has expired. Please sign in again.</p>
+          </div>
+        )}
+        {error && (
+          <div className="rounded-md bg-[var(--color-error-light)] p-4">
+            <p className="text-sm text-[var(--color-error)]">{error}</p>
+          </div>
+        )}
 
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           <div className="space-y-4">
             <div>
               <label
@@ -164,6 +164,27 @@ export default function LoginPage() {
             </button>
           </div>
         </form>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-[var(--color-border-medium)]" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-[var(--color-bg-secondary)] px-4 text-[var(--color-text-muted)]">
+              or
+            </span>
+          </div>
+        </div>
+
+        <div>
+          <a
+            href="/api/auth/google?source=login"
+            className="w-full flex items-center justify-center gap-3 py-2.5 px-4 border border-[var(--color-border-medium)] rounded-md bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors text-sm font-medium"
+          >
+            <span className="text-lg font-semibold">G</span>
+            Sign in with Google
+          </a>
+        </div>
 
         <div className="text-center">
           <Link

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -73,7 +73,28 @@ export default function SignupPage() {
           </p>
         </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+        <div className="mt-8">
+          <a
+            href="/api/auth/google?source=signup"
+            className="w-full flex items-center justify-center gap-3 py-2.5 px-4 border border-[var(--color-border-medium)] rounded-md bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors text-sm font-medium"
+          >
+            <span className="text-lg font-semibold">G</span>
+            Sign up with Google
+          </a>
+        </div>
+
+        <div className="relative my-6">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-[var(--color-border-medium)]" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-[var(--color-bg-secondary)] px-4 text-[var(--color-text-muted)]">
+              or sign up with email
+            </span>
+          </div>
+        </div>
+
+        <form className="space-y-6" onSubmit={handleSubmit}>
           {error && (
             <div className="rounded-md bg-[var(--color-error-light)] p-4">
               <p className="text-sm text-[var(--color-error)]">{error}</p>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -30,11 +30,13 @@ export async function sendWelcomeEmail({
   name,
   username,
   tempPassword,
+  isGoogleUser,
 }: {
   to: string
   name: string
   username: string
-  tempPassword: string
+  tempPassword?: string
+  isGoogleUser?: boolean
 }) {
   try {
     const resend = getResendClient()
@@ -43,6 +45,33 @@ export async function sendWelcomeEmail({
     }
 
     const config = getEmailConfig()
+
+    // Different email content for Google users vs password users
+    const loginDetailsHtml = isGoogleUser
+      ? `
+          <div style="background-color: #f3f4f6; border-radius: 8px; padding: 20px; margin: 24px 0;">
+            <p style="margin: 0 0 12px 0; color: #374151;"><strong>Your account:</strong></p>
+            <p style="margin: 0 0 8px 0; color: #374151;">Username: <strong>${username}</strong></p>
+            <p style="margin: 0; color: #374151;">Email: <strong>${to}</strong></p>
+          </div>
+
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            Sign in with the same Google account you used to apply.
+          </p>
+        `
+      : `
+          <div style="background-color: #f3f4f6; border-radius: 8px; padding: 20px; margin: 24px 0;">
+            <p style="margin: 0 0 12px 0; color: #374151;"><strong>Your login details:</strong></p>
+            <p style="margin: 0 0 8px 0; color: #374151;">Username: <strong>${username}</strong></p>
+            <p style="margin: 0 0 8px 0; color: #374151;">Email: <strong>${to}</strong></p>
+            <p style="margin: 0; color: #374151;">Temporary Password: <strong>${tempPassword}</strong></p>
+          </div>
+
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            Please change your password after logging in for the first time.
+          </p>
+        `
+
     const { data, error } = await resend.emails.send({
       from: `${APP_NAME} <${config.from}>`,
       to: [to],
@@ -56,19 +85,10 @@ export async function sendWelcomeEmail({
           </p>
 
           <p style="color: #374151; font-size: 16px; line-height: 1.6;">
-            Your membership request has been approved. You can now log in and start writing!
+            ${isGoogleUser ? 'Great news! Your writer access has been approved.' : 'Your membership request has been approved.'} You can now log in and start writing!
           </p>
 
-          <div style="background-color: #f3f4f6; border-radius: 8px; padding: 20px; margin: 24px 0;">
-            <p style="margin: 0 0 12px 0; color: #374151;"><strong>Your login details:</strong></p>
-            <p style="margin: 0 0 8px 0; color: #374151;">Username: <strong>${username}</strong></p>
-            <p style="margin: 0 0 8px 0; color: #374151;">Email: <strong>${to}</strong></p>
-            <p style="margin: 0; color: #374151;">Temporary Password: <strong>${tempPassword}</strong></p>
-          </div>
-
-          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
-            Please change your password after logging in for the first time.
-          </p>
+          ${loginDetailsHtml}
 
           <a href="${config.appUrl}/login" style="display: inline-block; background-color: #0D9488; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin-top: 16px;">
             Log in to ${APP_NAME}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,8 @@ export interface User {
   created_at: string
   updated_at: string
   last_login_at?: string
+  google_id?: string
+  auth_provider?: 'local' | 'google' | 'both'
 }
 
 export type PublicUser = Omit<User, 'password_hash' | 'email'>
@@ -33,6 +35,8 @@ export interface MembershipRequest {
   rejection_reason?: string
   created_at: string
   updated_at: string
+  google_id?: string
+  google_avatar_url?: string
 }
 
 // Post types


### PR DESCRIPTION
## Summary
- Add Google Sign In buttons to login, signup, and join pages
- Implement OAuth flow with automatic account linking by email
- Create choose-role page for new users signing in with Google
- Support Google users in membership approval flow

## Flows
1. **Login**: Sign in with Google → auto-links existing accounts by email, or shows choose-role page
2. **Signup**: Creates reader account immediately
3. **Join**: Creates membership request for admin approval

## Setup Required
- Run migration: `scripts/migration-google-oauth.sql`
- Add redirect URI in Google Cloud Console: `https://inkhouse.haripriya.org/api/auth/google/callback`

Closes #47