### PR TITLE
fix: Wait for preferences to load before applying reading filter

### DIFF
--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -16,10 +16,12 @@ export default function HomeContent({
   initialTotalPages,
   categories,
 }: HomeContentProps) {
-  const { isAuthenticated, isLoading } = useAuth()
-  const { viewMode, filter } = useReading()
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const { viewMode, filter, preferencesLoaded } = useReading()
 
-  // Don't show controls while loading auth state
+  // Show loading while auth or preferences are loading (for authenticated users)
+  const isLoading = authLoading || (isAuthenticated && !preferencesLoaded)
+
   if (isLoading) {
     return (
       <PostGrid

--- a/src/contexts/ReadingContext.tsx
+++ b/src/contexts/ReadingContext.tsx
@@ -7,6 +7,7 @@ import { useAuth } from './AuthContext'
 interface ReadingContextType {
   viewMode: ViewMode
   filter: ReadingFilter
+  preferencesLoaded: boolean
   setViewMode: (mode: ViewMode) => void
   setFilter: (filter: ReadingFilter) => void
 }
@@ -95,7 +96,7 @@ export function ReadingProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ReadingContext.Provider value={{ viewMode, filter, setViewMode, setFilter }}>
+    <ReadingContext.Provider value={{ viewMode, filter, preferencesLoaded: loaded, setViewMode, setFilter }}>
       {children}
     </ReadingContext.Provider>
   )
@@ -107,6 +108,7 @@ export function useReading() {
     return {
       viewMode: 'grid' as ViewMode,
       filter: 'all' as ReadingFilter,
+      preferencesLoaded: false,
       setViewMode: () => {},
       setFilter: () => {},
     }


### PR DESCRIPTION
## Summary
- Fixes issue where all posts briefly show before the reading filter is applied
- Adds `preferencesLoaded` to ReadingContext to track when user preferences are loaded
- HomeContent now waits for both auth AND preferences to load before applying filters

## Problem
When authenticated users load the home page, all posts would briefly flash before their preferred filter (e.g., "unread") was applied.

## Solution
Wait for preferences to load before switching from the default "all" filter to the user's saved preference.