### PR TITLE
fix: Add mounted check to prevent hydration flash of posts

### DIFF
--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import { PostWithAuthor } from '@/types'
 import { PostGrid } from '@/components/posts/PostGrid'
 import { useAuth } from '@/contexts/AuthContext'
@@ -16,11 +17,20 @@ export default function HomeContent({
   initialTotalPages,
   categories,
 }: HomeContentProps) {
+  const [mounted, setMounted] = useState(false)
   const { isAuthenticated, isLoading: authLoading } = useAuth()
   const { viewMode, filter, preferencesLoaded } = useReading()
 
-  // Show "INKING..." while auth or preferences are loading
-  if (authLoading || (isAuthenticated && !preferencesLoaded)) {
+  // Track when component has mounted (client-side hydration complete)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Show "INKING..." until:
+  // 1. Component is mounted (prevents flash during hydration)
+  // 2. Auth check is complete
+  // 3. If authenticated, preferences are loaded
+  if (!mounted || authLoading || (isAuthenticated && !preferencesLoaded)) {
     return (
       <div className="flex flex-col items-center justify-center py-24">
         <div className="text-2xl font-bold text-[var(--color-text-primary)] animate-pulse">


### PR DESCRIPTION
Add mounted state to ensure loading state shows until client-side JavaScript fully hydrates, preventing flash of unfiltered posts on production due to ISR static HTML caching.