### PR TITLE
fix: Show full-page loading until all data ready

### DIFF
--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -90,8 +90,16 @@ export default function HomeContent({
   const isFullyLoaded =
     mounted && !authLoading && (!isAuthenticated || (preferencesLoaded && statusesLoaded))
 
-  // Don't show full-page INKING here - loading.tsx handles page-level loading
-  // Instead, render PostGrid but pass loading state so it can show inline spinner
+  // Show full-page loading until ALL data is ready
+  // This prevents any partial UI from showing
+  if (!isFullyLoaded) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
+      </div>
+    )
+  }
+
   return (
     <PostGrid
       initialPosts={initialPosts}
@@ -101,7 +109,6 @@ export default function HomeContent({
       isAuthenticated={isAuthenticated}
       readingFilter={filter}
       initialReadStatuses={initialReadStatuses}
-      isInitialLoading={!isFullyLoaded}
     />
   )
 }

--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -17,7 +17,6 @@ interface PostGridProps {
   isAuthenticated?: boolean
   readingFilter?: ReadingFilter
   initialReadStatuses?: Record<number, string | null>
-  isInitialLoading?: boolean
 }
 
 export function PostGrid({
@@ -28,7 +27,6 @@ export function PostGrid({
   isAuthenticated = false,
   readingFilter = 'all',
   initialReadStatuses = {},
-  isInitialLoading = false,
 }: PostGridProps) {
   const { setFilter } = useReading()
   const [posts, setPosts] = useState<PostWithAuthor[]>(initialPosts)
@@ -478,7 +476,7 @@ export function PostGrid({
       </form>
 
       {/* Posts */}
-      {isInitialLoading || isLoading || statusesLoading ? (
+      {isLoading || statusesLoading ? (
         <div className="flex justify-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-button-primary)]"></div>
         </div>


### PR DESCRIPTION
- HomeContent shows spinner until auth, preferences, and read statuses are loaded
- Prevents partial UI (categories, search) from showing during data load
- PostGrid only renders when everything is ready