### PR TITLE
fix: Use browser-native base64url decoding for Google auth token

### DIFF
--- a/src/app/auth/google/choose-role/page.tsx
+++ b/src/app/auth/google/choose-role/page.tsx
@@ -28,7 +28,11 @@ function ChooseRoleForm() {
     }
 
     try {
-      const data = JSON.parse(Buffer.from(token, 'base64url').toString()) as GoogleUserData
+      // Convert base64url to base64 (replace - with +, _ with /, add padding)
+      const base64 = token.replace(/-/g, '+').replace(/_/g, '/')
+      const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+      const decoded = atob(padded)
+      const data = JSON.parse(decoded) as GoogleUserData
 
       // Check if token is expired (10 minutes)
       if (Date.now() - data.timestamp > 10 * 60 * 1000) {


### PR DESCRIPTION
## Summary
- Fix "invalid token" error when new users sign up with Google
- Replace `Buffer.from(token, 'base64url')` with browser-native `atob()` after base64url→base64 conversion
- The Buffer polyfill in browsers doesn't fully support base64url encoding

## Test plan
- [ ] Sign up as a new Google user via login flow
- [ ] Verify the choose-role page loads without "invalid token" error
- [ ] Complete signup and verify account is created