### PR TITLE
feat: Add writer critiques and analytics dashboard

### DIFF
--- a/scripts/migration-critiques-analytics.sql
+++ b/scripts/migration-critiques-analytics.sql
@@ -1,0 +1,47 @@
+-- Migration: Writer Critiques & Analytics
+-- Adds critiques (private peer reviews) and page_views (analytics) tables
+
+-- 1. Critiques table (private peer reviews between writers)
+CREATE TABLE IF NOT EXISTS critiques (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  parent_id UUID REFERENCES critiques(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'deleted')),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for critiques
+CREATE INDEX IF NOT EXISTS idx_critiques_post ON critiques(post_id);
+CREATE INDEX IF NOT EXISTS idx_critiques_author ON critiques(author_id);
+CREATE INDEX IF NOT EXISTS idx_critiques_parent ON critiques(parent_id);
+CREATE INDEX IF NOT EXISTS idx_critiques_created ON critiques(created_at DESC);
+
+-- Trigger for critiques updated_at
+CREATE OR REPLACE FUNCTION update_critiques_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_critiques_updated_at ON critiques;
+CREATE TRIGGER trigger_critiques_updated_at
+  BEFORE UPDATE ON critiques
+  FOR EACH ROW
+  EXECUTE FUNCTION update_critiques_updated_at();
+
+-- 2. Page views table (minimal analytics tracking)
+CREATE TABLE IF NOT EXISTS page_views (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  viewed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index for page_views (optimized for counting by post and time ranges)
+CREATE INDEX IF NOT EXISTS idx_page_views_post ON page_views(post_id);
+CREATE INDEX IF NOT EXISTS idx_page_views_viewed ON page_views(viewed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_page_views_post_viewed ON page_views(post_id, viewed_at);

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { AdminAnalytics } from '@/types'
+import { BarChart3, Users, FileText, Eye, PenLine, BookOpen, User } from 'lucide-react'
+import { StatsCard } from '@/components/analytics/StatsCard'
+import Image from 'next/image'
+
+export default function AdminAnalyticsPage() {
+  const [analytics, setAnalytics] = useState<AdminAnalytics | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      try {
+        const response = await fetch('/api/admin/analytics')
+        const data = await response.json()
+
+        if (data.success) {
+          setAnalytics(data.data)
+        } else {
+          setError(data.error || 'Failed to load analytics')
+        }
+      } catch {
+        setError('Failed to load analytics')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchAnalytics()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="h-7 w-48 bg-[var(--color-bg-tertiary)] rounded" />
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="bg-[var(--color-bg-card)] rounded-lg p-4 shadow-[var(--shadow-light)]">
+              <div className="h-8 w-16 bg-[var(--color-bg-tertiary)] rounded mb-2" />
+              <div className="h-4 w-24 bg-[var(--color-bg-tertiary)] rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[var(--color-error)]">{error}</p>
+      </div>
+    )
+  }
+
+  if (!analytics) {
+    return null
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-6">
+        <BarChart3 className="w-6 h-6 text-[var(--color-text-muted)]" />
+        <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Platform Analytics</h1>
+      </div>
+
+      <p className="text-[var(--color-text-muted)] mb-6">
+        Overview of Inkhouse platform activity.
+      </p>
+
+      {/* Stats Overview */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
+        <StatsCard
+          label="Total Users"
+          value={analytics.total_users}
+          icon={<Users className="w-5 h-5" />}
+          tooltip="All registered users"
+        />
+        <StatsCard
+          label="Writers"
+          value={analytics.total_writers}
+          icon={<PenLine className="w-5 h-5" />}
+          tooltip="Approved writers"
+        />
+        <StatsCard
+          label="Readers"
+          value={analytics.total_readers}
+          icon={<BookOpen className="w-5 h-5" />}
+          tooltip="Reader accounts"
+        />
+        <StatsCard
+          label="Published Posts"
+          value={analytics.total_posts}
+          icon={<FileText className="w-5 h-5" />}
+          tooltip="Live posts"
+        />
+        <StatsCard
+          label="Total Views"
+          value={analytics.total_views}
+          icon={<Eye className="w-5 h-5" />}
+          tooltip="All post views"
+        />
+      </div>
+
+      {/* Top Authors */}
+      <div className="bg-[var(--color-bg-card)] rounded-lg shadow-[var(--shadow-light)] p-4">
+        <h2 className="text-lg font-medium text-[var(--color-text-primary)] mb-4">
+          Top Authors
+        </h2>
+
+        {analytics.top_authors.length === 0 ? (
+          <p className="text-[var(--color-text-muted)] text-center py-8">
+            No authors with published posts yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[var(--color-border-light)]">
+                  <th className="text-left py-3 px-4 text-sm font-medium text-[var(--color-text-muted)]">
+                    Author
+                  </th>
+                  <th className="text-center py-3 px-4 text-sm font-medium text-[var(--color-text-muted)]">
+                    Posts
+                  </th>
+                  <th className="text-center py-3 px-4 text-sm font-medium text-[var(--color-text-muted)]">
+                    Views
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {analytics.top_authors.map((item, index) => (
+                  <tr
+                    key={index}
+                    className="border-b border-[var(--color-border-light)] hover:bg-[var(--color-bg-hover)]"
+                  >
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-3">
+                        {item.author?.avatar_url ? (
+                          <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0">
+                            <Image
+                              src={item.author.avatar_url}
+                              alt={item.author.display_name}
+                              width={32}
+                              height={32}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
+                        ) : (
+                          <div className="w-8 h-8 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
+                            <User className="w-4 h-4 text-[var(--color-link)]" />
+                          </div>
+                        )}
+                        <div>
+                          <p className="font-medium text-[var(--color-text-primary)]">
+                            {item.author?.display_name || 'Unknown'}
+                          </p>
+                          <p className="text-sm text-[var(--color-text-muted)]">
+                            @{item.author?.username}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="text-center py-3 px-4 text-[var(--color-text-secondary)]">
+                      {item.post_count}
+                    </td>
+                    <td className="text-center py-3 px-4 text-[var(--color-text-secondary)]">
+                      {item.total_views}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import { getAuthUser, isAdmin } from '@/lib/auth'
+import { AdminAnalytics } from '@/types'
+
+// GET - Get platform-wide analytics (admin only)
+export async function GET() {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser || !isAdmin(authUser)) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 403 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get counts in parallel
+    const [
+      { count: totalUsers },
+      { count: totalWriters },
+      { count: totalReaders },
+      { count: totalPosts },
+      { count: totalViews },
+      { data: topAuthorsData },
+    ] = await Promise.all([
+      supabase
+        .from('users')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'active'),
+      supabase
+        .from('users')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'active')
+        .in('role', ['writer', 'admin', 'super_admin']),
+      supabase
+        .from('users')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'active')
+        .eq('role', 'reader'),
+      supabase
+        .from('posts')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'published'),
+      supabase
+        .from('page_views')
+        .select('*', { count: 'exact', head: true }),
+      // Get top authors by post count
+      supabase
+        .from('posts')
+        .select(`
+          author_id,
+          author:users!posts_author_id_fkey(id, username, display_name, avatar_url)
+        `)
+        .eq('status', 'published'),
+    ])
+
+    // Calculate top authors
+    const authorCounts: Record<string, { author: unknown; count: number }> = {}
+    topAuthorsData?.forEach((post) => {
+      const authorId = post.author_id
+      if (!authorCounts[authorId]) {
+        authorCounts[authorId] = { author: post.author, count: 0 }
+      }
+      authorCounts[authorId].count++
+    })
+
+    // Get view counts for each author's posts
+    const topAuthors = await Promise.all(
+      Object.entries(authorCounts)
+        .sort(([, a], [, b]) => b.count - a.count)
+        .slice(0, 10)
+        .map(async ([authorId, data]) => {
+          // Get total views for this author's posts
+          const { data: authorPosts } = await supabase
+            .from('posts')
+            .select('id')
+            .eq('author_id', authorId)
+            .eq('status', 'published')
+
+          const postIds = authorPosts?.map((p) => p.id) || []
+          const { count: viewCount } = await supabase
+            .from('page_views')
+            .select('*', { count: 'exact', head: true })
+            .in('post_id', postIds)
+
+          return {
+            author: data.author,
+            post_count: data.count,
+            total_views: viewCount || 0,
+          }
+        })
+    )
+
+    const analytics: AdminAnalytics = {
+      total_users: totalUsers || 0,
+      total_writers: totalWriters || 0,
+      total_readers: totalReaders || 0,
+      total_posts: totalPosts || 0,
+      total_views: totalViews || 0,
+      user_growth: [], // Could add time-series data later
+      content_growth: [],
+      top_authors: topAuthors as AdminAnalytics['top_authors'],
+    }
+
+    return NextResponse.json({ success: true, data: analytics })
+  } catch (error) {
+    console.error('Admin analytics error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/analytics/post/[id]/route.ts
+++ b/src/app/api/analytics/post/[id]/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import { getAuthUser } from '@/lib/auth'
+import { PostAnalytics } from '@/types'
+
+// GET - Get detailed analytics for a specific post
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const postId = parseInt(id, 10)
+
+    if (isNaN(postId)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid post ID' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get the post
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select('id, title, normalized_title, author_id')
+      .eq('id', postId)
+      .single()
+
+    if (postError || !post) {
+      return NextResponse.json(
+        { success: false, error: 'Post not found' },
+        { status: 404 }
+      )
+    }
+
+    // Only post author or admin can view analytics
+    if (post.author_id !== authUser.userId && !['admin', 'super_admin'].includes(authUser.role)) {
+      return NextResponse.json(
+        { success: false, error: 'Not authorized' },
+        { status: 403 }
+      )
+    }
+
+    // Fetch all metrics in parallel
+    const [
+      { count: views },
+      { count: reads },
+      { count: boxAdditions },
+      { count: bookmarks },
+      { count: comments },
+      { count: critiques },
+    ] = await Promise.all([
+      supabase
+        .from('page_views')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId),
+      supabase
+        .from('post_reads')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId),
+      supabase
+        .from('reading_list_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId),
+      supabase
+        .from('bookmarks')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId),
+      supabase
+        .from('comments')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId)
+        .eq('status', 'approved'),
+      supabase
+        .from('critiques')
+        .select('*', { count: 'exact', head: true })
+        .eq('post_id', postId)
+        .eq('status', 'active'),
+    ])
+
+    const analytics: PostAnalytics = {
+      post_id: post.id,
+      title: post.title,
+      normalized_title: post.normalized_title,
+      views: views || 0,
+      reads: reads || 0,
+      box_additions: boxAdditions || 0,
+      bookmarks: bookmarks || 0,
+      comments: comments || 0,
+      critiques: critiques || 0,
+    }
+
+    return NextResponse.json({ success: true, data: analytics })
+  } catch (error) {
+    console.error('Post analytics error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+
+// POST - Track a page view (fire-and-forget, non-blocking)
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { post_id } = body
+
+    if (!post_id) {
+      return NextResponse.json({ success: false }, { status: 400 })
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json({ success: false }, { status: 503 })
+    }
+
+    // Insert page view (minimal data for performance)
+    await supabase.from('page_views').insert({
+      post_id: parseInt(post_id, 10),
+    })
+
+    return NextResponse.json({ success: true })
+  } catch {
+    // Fail silently - analytics should never break the user experience
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/src/app/api/analytics/writer/route.ts
+++ b/src/app/api/analytics/writer/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import { getAuthUser } from '@/lib/auth'
+import { PostAnalytics, WriterAnalytics } from '@/types'
+
+// GET - Get analytics for the authenticated writer
+export async function GET() {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get all published posts by this author
+    const { data: posts, error: postsError } = await supabase
+      .from('posts')
+      .select('id, title, normalized_title')
+      .eq('author_id', authUser.userId)
+      .eq('status', 'published')
+      .order('pub_date', { ascending: false })
+
+    if (postsError) {
+      console.error('Fetch posts error:', postsError)
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch posts' },
+        { status: 500 }
+      )
+    }
+
+    if (!posts || posts.length === 0) {
+      const emptyAnalytics: WriterAnalytics = {
+        total_posts: 0,
+        total_views: 0,
+        total_reads: 0,
+        total_box_additions: 0,
+        total_bookmarks: 0,
+        total_comments: 0,
+        total_critiques: 0,
+        posts: [],
+      }
+      return NextResponse.json({ success: true, data: emptyAnalytics })
+    }
+
+    const postIds = posts.map((p) => p.id)
+
+    // Fetch all metrics in parallel
+    const [
+      { data: viewsData },
+      { data: readsData },
+      { data: boxData },
+      { data: bookmarksData },
+      { data: commentsData },
+      { data: critiquesData },
+    ] = await Promise.all([
+      // Page views per post
+      supabase
+        .from('page_views')
+        .select('post_id')
+        .in('post_id', postIds),
+      // Reads per post
+      supabase
+        .from('post_reads')
+        .select('post_id')
+        .in('post_id', postIds),
+      // Box additions per post
+      supabase
+        .from('reading_list_items')
+        .select('post_id')
+        .in('post_id', postIds),
+      // Bookmarks per post
+      supabase
+        .from('bookmarks')
+        .select('post_id')
+        .in('post_id', postIds),
+      // Comments per post
+      supabase
+        .from('comments')
+        .select('post_id')
+        .in('post_id', postIds)
+        .eq('status', 'approved'),
+      // Critiques per post
+      supabase
+        .from('critiques')
+        .select('post_id')
+        .in('post_id', postIds)
+        .eq('status', 'active'),
+    ])
+
+    // Count per post
+    const countByPost = (data: { post_id: number }[] | null, postId: number) =>
+      data?.filter((d) => d.post_id === postId).length || 0
+
+    const postAnalytics: PostAnalytics[] = posts.map((post) => ({
+      post_id: post.id,
+      title: post.title,
+      normalized_title: post.normalized_title,
+      views: countByPost(viewsData, post.id),
+      reads: countByPost(readsData, post.id),
+      box_additions: countByPost(boxData, post.id),
+      bookmarks: countByPost(bookmarksData, post.id),
+      comments: countByPost(commentsData, post.id),
+      critiques: countByPost(critiquesData, post.id),
+    }))
+
+    // Calculate totals
+    const analytics: WriterAnalytics = {
+      total_posts: posts.length,
+      total_views: viewsData?.length || 0,
+      total_reads: readsData?.length || 0,
+      total_box_additions: boxData?.length || 0,
+      total_bookmarks: bookmarksData?.length || 0,
+      total_comments: commentsData?.length || 0,
+      total_critiques: critiquesData?.length || 0,
+      posts: postAnalytics,
+    }
+
+    return NextResponse.json({ success: true, data: analytics })
+  } catch (error) {
+    console.error('Writer analytics error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/critiques/[id]/route.ts
+++ b/src/app/api/critiques/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import { getAuthUser } from '@/lib/auth'
+
+// DELETE - Delete a critique (only the critique author can delete)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'Critique ID is required' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get the critique
+    const { data: critique, error: fetchError } = await supabase
+      .from('critiques')
+      .select('id, author_id')
+      .eq('id', id)
+      .single()
+
+    if (fetchError || !critique) {
+      return NextResponse.json(
+        { success: false, error: 'Critique not found' },
+        { status: 404 }
+      )
+    }
+
+    // Only the critique author can delete it
+    if (critique.author_id !== authUser.userId) {
+      return NextResponse.json(
+        { success: false, error: 'You can only delete your own critiques' },
+        { status: 403 }
+      )
+    }
+
+    // Soft delete by updating status
+    const { error } = await supabase
+      .from('critiques')
+      .update({ status: 'deleted' })
+      .eq('id', id)
+
+    if (error) {
+      console.error('Delete critique error:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to delete critique' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Critique deleted',
+    })
+  } catch (error) {
+    console.error('Delete critique error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/critiques/route.ts
+++ b/src/app/api/critiques/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+import { getAuthUser } from '@/lib/auth'
+import { sendNewCritiqueNotification } from '@/lib/email'
+
+// GET - Get critiques for a post (only visible to post author)
+export async function GET(request: NextRequest) {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const postId = searchParams.get('postId')
+
+    if (!postId) {
+      return NextResponse.json(
+        { success: false, error: 'Post ID is required' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get the post and verify user is the author
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select('id, author_id, title')
+      .eq('id', postId)
+      .single()
+
+    if (postError || !post) {
+      return NextResponse.json(
+        { success: false, error: 'Post not found' },
+        { status: 404 }
+      )
+    }
+
+    // Only post author can view critiques
+    if (post.author_id !== authUser.userId) {
+      return NextResponse.json(
+        { success: false, error: 'Only the post author can view critiques' },
+        { status: 403 }
+      )
+    }
+
+    // Fetch critiques with author info
+    const { data: critiques, error } = await supabase
+      .from('critiques')
+      .select(`
+        *,
+        author:users!critiques_author_id_fkey(id, username, display_name, avatar_url)
+      `)
+      .eq('post_id', postId)
+      .eq('status', 'active')
+      .order('created_at', { ascending: true })
+
+    if (error) {
+      console.error('Fetch critiques error:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch critiques' },
+        { status: 500 }
+      )
+    }
+
+    // Organize into threads
+    const rootCritiques = critiques?.filter((c) => !c.parent_id) || []
+    const replies = critiques?.filter((c) => c.parent_id) || []
+
+    const threaded = rootCritiques.map((critique) => ({
+      ...critique,
+      replies: replies.filter((r) => r.parent_id === critique.id),
+    }))
+
+    return NextResponse.json({
+      success: true,
+      data: threaded,
+    })
+  } catch (error) {
+    console.error('Fetch critiques error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// POST - Create a critique (writers only, cannot critique own posts)
+export async function POST(request: NextRequest) {
+  try {
+    const authUser = await getAuthUser()
+    if (!authUser) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    // Only writers/admins can leave critiques
+    if (!['writer', 'admin', 'super_admin'].includes(authUser.role)) {
+      return NextResponse.json(
+        { success: false, error: 'Only writers can leave critiques' },
+        { status: 403 }
+      )
+    }
+
+    const body = await request.json()
+    const { post_id, content, parent_id } = body
+
+    if (!post_id || !content) {
+      return NextResponse.json(
+        { success: false, error: 'Post ID and content are required' },
+        { status: 400 }
+      )
+    }
+
+    if (content.trim().length < 10) {
+      return NextResponse.json(
+        { success: false, error: 'Critique must be at least 10 characters' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createServerClient()
+    if (!supabase) {
+      return NextResponse.json(
+        { success: false, error: 'Database not configured' },
+        { status: 503 }
+      )
+    }
+
+    // Get post and author info
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select(`
+        id,
+        title,
+        normalized_title,
+        author_id,
+        author:users!posts_author_id_fkey(id, email, display_name)
+      `)
+      .eq('id', post_id)
+      .eq('status', 'published')
+      .single()
+
+    if (postError || !post) {
+      return NextResponse.json(
+        { success: false, error: 'Post not found' },
+        { status: 404 }
+      )
+    }
+
+    // Cannot critique your own post
+    if (post.author_id === authUser.userId) {
+      return NextResponse.json(
+        { success: false, error: 'You cannot critique your own post' },
+        { status: 403 }
+      )
+    }
+
+    // Get critiquer's name for notification
+    const { data: critiquer } = await supabase
+      .from('users')
+      .select('display_name')
+      .eq('id', authUser.userId)
+      .single()
+
+    // If replying, verify parent critique exists and belongs to this post
+    if (parent_id) {
+      const { data: parentCritique } = await supabase
+        .from('critiques')
+        .select('id, post_id')
+        .eq('id', parent_id)
+        .eq('status', 'active')
+        .single()
+
+      if (!parentCritique || parentCritique.post_id !== post_id) {
+        return NextResponse.json(
+          { success: false, error: 'Invalid parent critique' },
+          { status: 400 }
+        )
+      }
+    }
+
+    // Create the critique
+    const { data: critique, error } = await supabase
+      .from('critiques')
+      .insert({
+        post_id,
+        author_id: authUser.userId,
+        content: content.trim(),
+        parent_id: parent_id || null,
+        status: 'active',
+      })
+      .select(`
+        *,
+        author:users!critiques_author_id_fkey(id, username, display_name, avatar_url)
+      `)
+      .single()
+
+    if (error) {
+      console.error('Create critique error:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to create critique' },
+        { status: 500 }
+      )
+    }
+
+    // Send email notification to post author (non-blocking)
+    // Only notify for new critiques, not replies
+    if (!parent_id && post.author) {
+      // Supabase joins may return array or object depending on relation type
+      const authorData = Array.isArray(post.author) ? post.author[0] : post.author
+      if (authorData?.email) {
+        sendNewCritiqueNotification({
+          to: authorData.email,
+          authorName: authorData.display_name,
+          postTitle: post.title,
+          postSlug: post.normalized_title,
+          critiquerName: critiquer?.display_name || authUser.username,
+        }).catch((err) => console.error('Failed to send critique notification:', err))
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: critique,
+    })
+  } catch (error) {
+    console.error('Create critique error:', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -3,60 +3,69 @@ import { getAuthUser, isSuperAdmin } from '@/lib/auth'
 import { createServerClient } from '@/lib/supabase'
 import { sendNewsletter } from '@/lib/email'
 
-const NEW_YEAR_2025_HTML = `
+const NEWSLETTER_HTML = `
 <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #374151;">
-  <p style="font-size: 16px; line-height: 1.8;">Hi there,</p>
-
-  <p style="font-size: 16px; line-height: 1.8;">
-    As we step into 2025, I wanted to take a moment to thank you for being part of Inkhouse.
+  <p style="font-size: 12px; color: #9ca3af; margin-bottom: 24px;">
+    January 1, 2026 · 1 min read
   </p>
 
   <p style="font-size: 16px; line-height: 1.8;">
-    This past year, I've been thinking deeply about what it means to read online. In a world of endless feeds and algorithmic recommendations, I wanted Inkhouse to feel different. A place where <em>you</em> decide what to read, when to read it, and how to organize your reading life.
+    Today, I introduced a couple of features to Inkhouse, intentionally avoiding likes, subscriptions, and notifications.
   </p>
 
-  <h3 style="color: #0D9488; margin-top: 32px;">Your reading, your way</h3>
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+
   <p style="font-size: 16px; line-height: 1.8;">
-    You can now track what you've read and what's waiting for you. No pressure, no notifications nagging you. Just a simple way to know where you left off. When you've caught up, you'll simply see "You're all caught up!" and that's it.
+    A single "like" flattens too much. You may appreciate the writing but not agree with the idea. You may agree with the idea but not the way it is expressed. You may simply want to think about it longer. Reducing all of that to one action takes away the reader's agency.
   </p>
 
-  <h3 style="color: #0D9488; margin-top: 32px;">Boxes for your thoughts</h3>
   <p style="font-size: 16px; line-height: 1.8;">
-    Found a post you want to save for later? Create a box. Call it "Weekend reads" or "Ideas to revisit" or whatever makes sense to you. Your boxes are yours. A personal library that grows with your interests.
+    Instead, Inkhouse treats reading as a relationship, not a reaction. You can mark something as read, return to it later, or save it into a <strong>Box</strong> if it matters to you. Boxes exist so that writing can be revisited, not just acknowledged and forgotten.
   </p>
 
-  <h3 style="color: #0D9488; margin-top: 32px;">A home on any screen</h3>
+  <p style="font-size: 16px; line-height: 1.8; font-style: italic; color: #0D9488;">
+    If an idea stays with you, it deserves a place, not a count.
+  </p>
+
   <p style="font-size: 16px; line-height: 1.8;">
-    Whether you're reading on your phone during a commute or at your desk with a cup of coffee, Inkhouse adapts. On mobile, I've made things lighter and faster. Compact views that get out of your way and let the words breathe.
+    Discussions remain open through comments. Nothing demands a response.
   </p>
 
-  <h3 style="color: #0D9488; margin-top: 32px;">From the Desk</h3>
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;" />
+
   <p style="font-size: 16px; line-height: 1.8;">
-    I've also created a little corner called "From the Desk". A place for updates, stories, and reflections from behind the scenes at Inkhouse.
+    Platform decisions follow the same philosophy.
   </p>
 
-  <div style="border-top: 1px solid #e5e7eb; margin-top: 40px; padding-top: 24px;">
-    <p style="font-size: 16px; line-height: 1.8;">
-      Thank you for reading, for writing, and for being here. Here's to more words, more stories, and more moments of connection in 2025.
-    </p>
+  <p style="font-size: 16px; line-height: 1.8;">
+    Inkhouse is an open source project. While I run the platform, I do not believe decisions about its direction should be made unilaterally. Writers can propose ideas, discuss them, and vote. When a suggestion receives majority support, it becomes a real signal to act. If more than half the writers want something, I commit to implementing it.
+  </p>
 
-    <p style="font-size: 16px; line-height: 1.8;">
-      Happy New Year!
-    </p>
+  <p style="font-size: 16px; line-height: 1.8;">
+    I introduced a feature where &gt;50% of upvotes on any suggestion will be notified to me and raised as a GitHub issue.
+  </p>
 
-    <p style="font-size: 16px; line-height: 1.8; margin-top: 24px;">
-      Warm regards,<br/>
-      Haripriya
-    </p>
-  </div>
+  <p style="font-size: 16px; line-height: 1.8; font-style: italic; color: #0D9488;">
+    Nothing ships silently. Nothing is decided in private.
+  </p>
+
+  <p style="font-size: 16px; line-height: 1.8;">
+    The intention is to build like a library. Shaped by its readers and writers, and governed by the people who choose to stay.
+  </p>
+
+  <p style="font-size: 16px; line-height: 1.8; margin-top: 24px;">
+    Warm regards,<br/>
+    Haripriya
+  </p>
 
   <p style="font-size: 12px; color: #9ca3af; margin-top: 40px; text-align: center;">
-    <a href="https://inkhouse.haripriya.org" style="color: #0D9488;">Inkhouse</a>. A home for writers
+    <a href="https://inkhouse.haripriya.org" style="color: #0D9488;">Inkhouse</a> · A home for writers
   </p>
 </div>
 `
 
 export async function POST(request: NextRequest) {
+  console.log('=== SENDING NEW NEWSLETTER: Writing Together, Deciding Together ===')
   try {
     // Verify super admin
     const user = await getAuthUser()
@@ -126,8 +135,8 @@ export async function POST(request: NextRequest) {
       const result = await sendNewsletter({
         to: user.email,
         name: user.display_name,
-        subject: 'Happy New Year from Inkhouse 🎉',
-        html: NEW_YEAR_2025_HTML,
+        subject: 'Writing Together, Deciding Together',
+        html: NEWSLETTER_HTML,
       })
 
       if (result.success) {

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { WriterAnalytics } from '@/types'
+import { BarChart3, Eye, BookOpen, Box, MessageSquare, MessageSquareLock } from 'lucide-react'
+import { StatsCard } from '@/components/analytics/StatsCard'
+import { PostStatsTable } from '@/components/analytics/PostStatsTable'
+
+export default function AnalyticsPage() {
+  const [analytics, setAnalytics] = useState<WriterAnalytics | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      try {
+        const response = await fetch('/api/analytics/writer')
+        const data = await response.json()
+
+        if (data.success) {
+          setAnalytics(data.data)
+        } else {
+          setError(data.error || 'Failed to load analytics')
+        }
+      } catch {
+        setError('Failed to load analytics')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchAnalytics()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="h-7 w-32 bg-[var(--color-bg-tertiary)] rounded" />
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 mb-8">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="bg-[var(--color-bg-card)] rounded-lg p-4 shadow-[var(--shadow-light)]">
+              <div className="h-8 w-16 bg-[var(--color-bg-tertiary)] rounded mb-2" />
+              <div className="h-4 w-24 bg-[var(--color-bg-tertiary)] rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[var(--color-error)]">{error}</p>
+      </div>
+    )
+  }
+
+  if (!analytics) {
+    return null
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-6">
+        <BarChart3 className="w-6 h-6 text-[var(--color-text-muted)]" />
+        <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Analytics</h1>
+      </div>
+
+      <p className="text-[var(--color-text-muted)] mb-6">
+        See how readers are engaging with your writing.
+      </p>
+
+      {/* Stats Overview */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 mb-8">
+        <StatsCard
+          label="Total Views"
+          value={analytics.total_views}
+          icon={<Eye className="w-5 h-5" />}
+          tooltip="Tracked from Jan 2026"
+        />
+        <StatsCard
+          label="Total Reads"
+          value={analytics.total_reads}
+          icon={<BookOpen className="w-5 h-5" />}
+          tooltip="Marked as read"
+        />
+        <StatsCard
+          label="Box Additions"
+          value={analytics.total_box_additions}
+          icon={<Box className="w-5 h-5" />}
+          tooltip="Added to reading list"
+        />
+        <StatsCard
+          label="Comments"
+          value={analytics.total_comments}
+          icon={<MessageSquare className="w-5 h-5" />}
+          tooltip="Reader comments"
+        />
+        <StatsCard
+          label="Critiques"
+          value={analytics.total_critiques}
+          icon={<MessageSquareLock className="w-5 h-5" />}
+          tooltip="Writer peer reviews"
+        />
+        <StatsCard
+          label="Published Posts"
+          value={analytics.total_posts}
+        />
+      </div>
+
+      {/* Legend */}
+      <div className="hidden sm:flex flex-wrap gap-4 mb-4 text-sm text-[var(--color-text-muted)]">
+        <span className="flex items-center gap-1">
+          <Eye className="w-4 h-4" /> Views - Post opened (from Jan 2026)
+        </span>
+        <span className="flex items-center gap-1">
+          <BookOpen className="w-4 h-4" /> Reads - Marked as read
+        </span>
+        <span className="flex items-center gap-1">
+          <Box className="w-4 h-4" /> Box - Added to reading list
+        </span>
+      </div>
+
+      {/* Posts Table */}
+      <div className="bg-[var(--color-bg-card)] rounded-lg shadow-[var(--shadow-light)] p-4">
+        <h2 className="text-lg font-medium text-[var(--color-text-primary)] mb-4">
+          Post Performance
+        </h2>
+        <PostStatsTable posts={analytics.posts} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/dashboard/critiques/page.tsx
+++ b/src/app/dashboard/critiques/page.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Post, CritiqueWithAuthor } from '@/types'
+import { MessageSquareLock, ChevronDown, ChevronRight, FileText } from 'lucide-react'
+import { PostCritiquesView } from '@/components/critiques/PostCritiquesView'
+import Link from 'next/link'
+
+interface PostWithCritiques extends Post {
+  critiques: CritiqueWithAuthor[]
+  critique_count: number
+}
+
+export default function CritiquesPage() {
+  const [posts, setPosts] = useState<PostWithCritiques[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [expandedPost, setExpandedPost] = useState<number | null>(null)
+
+  const fetchPostsWithCritiques = useCallback(async () => {
+    try {
+      // First get all posts
+      const postsResponse = await fetch('/api/posts/my')
+      const postsData = await postsResponse.json()
+
+      if (!postsData.success) return
+
+      // For each post, fetch critiques
+      const postsWithCritiques: PostWithCritiques[] = await Promise.all(
+        postsData.data.map(async (post: Post) => {
+          try {
+            const critiquesResponse = await fetch(`/api/critiques?postId=${post.id}`)
+            const critiquesData = await critiquesResponse.json()
+            return {
+              ...post,
+              critiques: critiquesData.success ? critiquesData.data : [],
+              critique_count: critiquesData.success ? critiquesData.data.length : 0,
+            }
+          } catch {
+            return { ...post, critiques: [], critique_count: 0 }
+          }
+        })
+      )
+
+      // Only show posts with critiques, sorted by most recent critique
+      const filtered = postsWithCritiques
+        .filter((p) => p.critique_count > 0)
+        .sort((a, b) => {
+          const aLatest = a.critiques[a.critiques.length - 1]?.created_at || ''
+          const bLatest = b.critiques[b.critiques.length - 1]?.created_at || ''
+          return bLatest.localeCompare(aLatest)
+        })
+
+      setPosts(filtered)
+    } catch (error) {
+      console.error('Failed to fetch critiques:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchPostsWithCritiques()
+  }, [fetchPostsWithCritiques])
+
+  const handleRefresh = () => {
+    fetchPostsWithCritiques()
+  }
+
+  const totalCritiques = posts.reduce((sum, p) => sum + p.critique_count, 0)
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="h-7 w-40 bg-[var(--color-bg-tertiary)] rounded" />
+        </div>
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-[var(--color-bg-card)] rounded-lg p-4 shadow-[var(--shadow-light)]">
+              <div className="h-5 w-64 bg-[var(--color-bg-tertiary)] rounded mb-2" />
+              <div className="h-4 w-32 bg-[var(--color-bg-tertiary)] rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-6">
+        <MessageSquareLock className="w-6 h-6 text-[var(--color-text-muted)]" />
+        <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Critiques</h1>
+        {totalCritiques > 0 && (
+          <span className="px-2 py-0.5 text-sm bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] rounded-full">
+            {totalCritiques}
+          </span>
+        )}
+      </div>
+
+      <p className="text-[var(--color-text-muted)] mb-6">
+        Private feedback from fellow writers on your posts. Only you can see these.
+      </p>
+
+      {posts.length === 0 ? (
+        <div className="text-center py-12 bg-[var(--color-bg-card)] rounded-lg shadow-[var(--shadow-light)]">
+          <FileText className="w-12 h-12 text-[var(--color-text-muted)] mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">
+            No critiques yet
+          </h3>
+          <p className="text-[var(--color-text-muted)]">
+            When other writers leave feedback on your posts, you&apos;ll see it here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {posts.map((post) => (
+            <div
+              key={post.id}
+              className="bg-[var(--color-bg-card)] rounded-lg shadow-[var(--shadow-light)] overflow-hidden"
+            >
+              <button
+                onClick={() => setExpandedPost(expandedPost === post.id ? null : post.id)}
+                className="w-full p-4 flex items-center justify-between text-left hover:bg-[var(--color-bg-hover)] transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-medium text-[var(--color-text-primary)] truncate">
+                      {post.title}
+                    </h3>
+                    <span className="px-2 py-0.5 text-xs bg-[var(--color-link-light)] text-[var(--color-link)] rounded-full flex-shrink-0">
+                      {post.critique_count} {post.critique_count === 1 ? 'critique' : 'critiques'}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 mt-1 text-sm text-[var(--color-text-muted)]">
+                    <Link
+                      href={`/post/${post.normalized_title}`}
+                      className="hover:text-[var(--color-link)]"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      View post
+                    </Link>
+                  </div>
+                </div>
+                {expandedPost === post.id ? (
+                  <ChevronDown className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+                ) : (
+                  <ChevronRight className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+                )}
+              </button>
+
+              {expandedPost === post.id && (
+                <div className="p-4 pt-0 border-t border-[var(--color-border-light)]">
+                  <PostCritiquesView
+                    postId={post.id}
+                    postTitle={post.title}
+                    critiques={post.critiques}
+                    onRefresh={handleRefresh}
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { Calendar, User, ArrowLeft, Globe, Twitter, Github, Linkedin } from 'luc
 import { createServerClient } from '@/lib/supabase'
 import parse from 'html-react-parser'
 import { CommentsSection } from '@/components/comments/CommentsSection'
+import { CritiqueSection } from '@/components/critiques/CritiqueSection'
+import { ViewTracker } from '@/components/analytics/ViewTracker'
 
 // Revalidate every 60 seconds
 export const revalidate = 60
@@ -66,6 +68,9 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
       <Navbar />
 
       <article className="max-w-3xl mx-auto px-4 py-8">
+        {/* Track page view */}
+        <ViewTracker postId={post.id} />
+
         {/* Back link */}
         <Link
           href="/"
@@ -189,6 +194,9 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
         {/* Comments */}
         <CommentsSection postId={post.id} allowComments={post.allow_comments !== false} />
+
+        {/* Critique Section (for writers only) */}
+        <CritiqueSection postId={post.id} postAuthorId={post.author_id} />
       </article>
 
       {/* Footer */}

--- a/src/components/analytics/PostStatsTable.tsx
+++ b/src/components/analytics/PostStatsTable.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import { PostAnalytics } from '@/types'
+import { Eye, BookOpen, Box, MessageSquare, MessageSquareLock } from 'lucide-react'
+
+interface PostStatsTableProps {
+  posts: PostAnalytics[]
+}
+
+export function PostStatsTable({ posts }: PostStatsTableProps) {
+  if (posts.length === 0) {
+    return (
+      <div className="text-center py-8 text-[var(--color-text-muted)]">
+        No published posts yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto pt-8 -mt-8">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-[var(--color-border-light)]">
+            <th className="text-left py-3 px-4 text-sm font-medium text-[var(--color-text-muted)]">
+              Post
+            </th>
+            <th className="text-center py-3 px-2 text-sm font-medium text-[var(--color-text-muted)] group relative">
+              <Eye className="w-4 h-4 inline" />
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                Views (from Jan 2026)
+              </span>
+            </th>
+            <th className="text-center py-3 px-2 text-sm font-medium text-[var(--color-text-muted)] group relative">
+              <BookOpen className="w-4 h-4 inline" />
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                Reads
+              </span>
+            </th>
+            <th className="text-center py-3 px-2 text-sm font-medium text-[var(--color-text-muted)] group relative">
+              <Box className="w-4 h-4 inline" />
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                Box Additions
+              </span>
+            </th>
+            <th className="text-center py-3 px-2 text-sm font-medium text-[var(--color-text-muted)] group relative">
+              <MessageSquare className="w-4 h-4 inline" />
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                Comments
+              </span>
+            </th>
+            <th className="text-center py-3 px-2 text-sm font-medium text-[var(--color-text-muted)] group relative">
+              <MessageSquareLock className="w-4 h-4 inline" />
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                Critiques
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map((post) => (
+            <tr
+              key={post.post_id}
+              className="border-b border-[var(--color-border-light)] hover:bg-[var(--color-bg-hover)]"
+            >
+              <td className="py-3 px-4">
+                <Link
+                  href={`/post/${post.normalized_title}`}
+                  className="text-[var(--color-text-primary)] hover:text-[var(--color-link)] font-medium"
+                >
+                  {post.title}
+                </Link>
+              </td>
+              <td className="text-center py-3 px-2 text-[var(--color-text-secondary)]">
+                {post.views}
+              </td>
+              <td className="text-center py-3 px-2 text-[var(--color-text-secondary)]">
+                {post.reads}
+              </td>
+              <td className="text-center py-3 px-2 text-[var(--color-text-secondary)]">
+                {post.box_additions}
+              </td>
+              <td className="text-center py-3 px-2 text-[var(--color-text-secondary)]">
+                {post.comments}
+              </td>
+              <td className="text-center py-3 px-2 text-[var(--color-text-secondary)]">
+                {post.critiques}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Legend for mobile */}
+      <div className="mt-4 flex flex-wrap gap-4 text-xs text-[var(--color-text-muted)] sm:hidden">
+        <span className="flex items-center gap-1">
+          <Eye className="w-3 h-3" /> Views*
+        </span>
+        <span className="flex items-center gap-1">
+          <BookOpen className="w-3 h-3" /> Reads
+        </span>
+        <span className="flex items-center gap-1">
+          <Box className="w-3 h-3" /> Box
+        </span>
+        <span className="flex items-center gap-1">
+          <MessageSquare className="w-3 h-3" /> Comments
+        </span>
+        <span className="flex items-center gap-1">
+          <MessageSquareLock className="w-3 h-3" /> Critiques
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/analytics/StatsCard.tsx
+++ b/src/components/analytics/StatsCard.tsx
@@ -1,0 +1,31 @@
+interface StatsCardProps {
+  label: string
+  value: number
+  icon?: React.ReactNode
+  tooltip?: string
+}
+
+export function StatsCard({ label, value, icon, tooltip }: StatsCardProps) {
+  return (
+    <div className="bg-[var(--color-bg-card)] rounded-lg p-4 shadow-[var(--shadow-light)] overflow-visible">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-2xl font-bold text-[var(--color-text-primary)]">
+            {value.toLocaleString()}
+          </p>
+          <p className="text-sm text-[var(--color-text-muted)]">{label}</p>
+        </div>
+        {icon && (
+          <div className="text-[var(--color-text-muted)] group relative">
+            {icon}
+            {tooltip && (
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                {tooltip}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/analytics/ViewTracker.tsx
+++ b/src/components/analytics/ViewTracker.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface ViewTrackerProps {
+  postId: number
+}
+
+export function ViewTracker({ postId }: ViewTrackerProps) {
+  const tracked = useRef(false)
+
+  useEffect(() => {
+    // Only track once per page load
+    if (tracked.current) return
+    tracked.current = true
+
+    // Use sendBeacon for non-blocking tracking
+    // Falls back to fetch if sendBeacon is not available
+    const trackView = () => {
+      const data = JSON.stringify({ post_id: postId })
+
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon('/api/analytics/track', data)
+      } else {
+        // Fallback for older browsers
+        fetch('/api/analytics/track', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: data,
+          keepalive: true,
+        }).catch(() => {
+          // Fail silently
+        })
+      }
+    }
+
+    // Small delay to ensure the page has loaded
+    const timer = setTimeout(trackView, 100)
+    return () => clearTimeout(timer)
+  }, [postId])
+
+  // This component renders nothing
+  return null
+}

--- a/src/components/critiques/CritiqueSection.tsx
+++ b/src/components/critiques/CritiqueSection.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { MessageSquareLock } from 'lucide-react'
+
+interface CritiqueSectionProps {
+  postId: number
+  postAuthorId: string
+}
+
+export function CritiqueSection({ postId, postAuthorId }: CritiqueSectionProps) {
+  const { user, isAuthenticated } = useAuth()
+  const [content, setContent] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  // Only show for authenticated writers who are not the post author
+  if (!isAuthenticated || !user) return null
+  if (!['writer', 'admin', 'super_admin'].includes(user.role)) return null
+  if (user.id === postAuthorId) return null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!content.trim() || content.trim().length < 10) {
+      setMessage({ type: 'error', text: 'Critique must be at least 10 characters' })
+      return
+    }
+
+    setIsSubmitting(true)
+    setMessage(null)
+
+    try {
+      const response = await fetch('/api/critiques', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          post_id: postId,
+          content: content.trim(),
+        }),
+      })
+
+      const data = await response.json()
+      if (data.success) {
+        setContent('')
+        setMessage({ type: 'success', text: 'Critique sent! Only the author will see this.' })
+      } else {
+        setMessage({ type: 'error', text: data.error || 'Failed to send critique' })
+      }
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to send critique' })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mt-8 p-6 bg-[var(--color-bg-tertiary)] rounded-lg border border-[var(--color-border-light)]">
+      <div className="flex items-center gap-2 mb-4">
+        <MessageSquareLock className="w-5 h-5 text-[var(--color-text-muted)]" />
+        <h3 className="text-lg font-medium text-[var(--color-text-primary)]">
+          Leave a Critique
+        </h3>
+      </div>
+
+      <p className="text-sm text-[var(--color-text-muted)] mb-4">
+        As a fellow writer, you can leave private feedback for the author.
+        Only they will see your critique.
+      </p>
+
+      {message && (
+        <div
+          className={`p-3 rounded-md mb-4 ${
+            message.type === 'success'
+              ? 'bg-green-50 text-green-800 dark:bg-green-900/20 dark:text-green-400'
+              : 'bg-red-50 text-red-800 dark:bg-red-900/20 dark:text-red-400'
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Share your thoughts on this piece..."
+          rows={4}
+          className="w-full px-4 py-3 border border-[var(--color-border-medium)] rounded-md text-[var(--color-text-primary)] bg-[var(--color-bg-card)] mb-4 focus:ring-1 focus:ring-[var(--color-link)] focus:border-[var(--color-link)] focus:outline-none resize-none"
+        />
+        <button
+          type="submit"
+          disabled={isSubmitting || !content.trim()}
+          className="btn-primary px-6 py-2 rounded-md disabled:opacity-50"
+        >
+          {isSubmitting ? 'Sending...' : 'Send Critique'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/critiques/PostCritiquesView.tsx
+++ b/src/components/critiques/PostCritiquesView.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { useState } from 'react'
+import { CritiqueWithAuthor } from '@/types'
+import { User, Reply, Trash2 } from 'lucide-react'
+import Image from 'next/image'
+
+interface PostCritiquesViewProps {
+  postId: number
+  postTitle: string
+  critiques: CritiqueWithAuthor[]
+  onRefresh: () => void
+}
+
+export function PostCritiquesView({
+  postId,
+  postTitle,
+  critiques,
+  onRefresh,
+}: PostCritiquesViewProps) {
+  const [replyingTo, setReplyingTo] = useState<string | null>(null)
+  const [replyContent, setReplyContent] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleReply = async (parentId: string) => {
+    if (!replyContent.trim() || replyContent.trim().length < 10) return
+
+    setIsSubmitting(true)
+    try {
+      const response = await fetch('/api/critiques', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          post_id: postId,
+          content: replyContent.trim(),
+          parent_id: parentId,
+        }),
+      })
+
+      const data = await response.json()
+      if (data.success) {
+        setReplyContent('')
+        setReplyingTo(null)
+        onRefresh()
+      }
+    } catch (error) {
+      console.error('Failed to post reply:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (critiqueId: string) => {
+    if (!confirm('Delete this critique?')) return
+
+    try {
+      const response = await fetch(`/api/critiques/${critiqueId}`, {
+        method: 'DELETE',
+      })
+
+      if (response.ok) {
+        onRefresh()
+      }
+    } catch (error) {
+      console.error('Failed to delete critique:', error)
+    }
+  }
+
+  if (critiques.length === 0) {
+    return (
+      <div className="text-center py-8 text-[var(--color-text-muted)]">
+        No critiques yet for this post.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-medium text-[var(--color-text-primary)]">
+        Critiques on &ldquo;{postTitle}&rdquo;
+      </h3>
+
+      {critiques.map((critique) => (
+        <div key={critique.id} className="border border-[var(--color-border-light)] rounded-lg p-4">
+          <div className="flex space-x-4">
+            {critique.author?.avatar_url ? (
+              <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+                <Image
+                  src={critique.author.avatar_url}
+                  alt={critique.author.display_name}
+                  width={40}
+                  height={40}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            ) : (
+              <div className="w-10 h-10 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
+                <User className="w-5 h-5 text-[var(--color-link)]" />
+              </div>
+            )}
+            <div className="flex-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <span className="font-medium text-[var(--color-text-primary)]">
+                    {critique.author?.display_name || 'Unknown'}
+                  </span>
+                  <span className="text-sm text-[var(--color-text-muted)]">
+                    {new Date(critique.created_at).toLocaleDateString('en-GB', {
+                      day: 'numeric',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </div>
+                <button
+                  onClick={() => setReplyingTo(replyingTo === critique.id ? null : critique.id)}
+                  className="text-[var(--color-text-muted)] hover:text-[var(--color-link)] flex items-center gap-1 text-sm"
+                >
+                  <Reply className="w-4 h-4" />
+                  Reply
+                </button>
+              </div>
+              <p className="mt-2 text-[var(--color-text-secondary)] whitespace-pre-wrap">
+                {critique.content}
+              </p>
+
+              {/* Reply form */}
+              {replyingTo === critique.id && (
+                <div className="mt-4 pl-4 border-l-2 border-[var(--color-border-light)]">
+                  <textarea
+                    value={replyContent}
+                    onChange={(e) => setReplyContent(e.target.value)}
+                    placeholder="Write your reply..."
+                    rows={3}
+                    className="w-full px-3 py-2 border border-[var(--color-border-medium)] rounded-md text-[var(--color-text-primary)] bg-[var(--color-bg-card)] text-sm focus:ring-1 focus:ring-[var(--color-link)] focus:border-[var(--color-link)] focus:outline-none resize-none"
+                  />
+                  <div className="flex gap-2 mt-2">
+                    <button
+                      onClick={() => handleReply(critique.id)}
+                      disabled={isSubmitting || !replyContent.trim()}
+                      className="btn-primary px-4 py-1.5 rounded-md text-sm disabled:opacity-50"
+                    >
+                      {isSubmitting ? 'Sending...' : 'Send Reply'}
+                    </button>
+                    <button
+                      onClick={() => {
+                        setReplyingTo(null)
+                        setReplyContent('')
+                      }}
+                      className="px-4 py-1.5 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Replies */}
+              {critique.replies && critique.replies.length > 0 && (
+                <div className="mt-4 ml-6 space-y-4 border-l-2 border-[var(--color-border-light)] pl-4">
+                  {critique.replies.map((reply) => (
+                    <div key={reply.id} className="flex space-x-3">
+                      <div className="w-8 h-8 rounded-full bg-[var(--color-bg-tertiary)] flex items-center justify-center flex-shrink-0">
+                        <User className="w-4 h-4 text-[var(--color-link)]" />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center space-x-2">
+                            <span className="font-medium text-[var(--color-text-primary)] text-sm">
+                              {reply.author?.display_name || 'Unknown'}
+                            </span>
+                            <span className="text-xs text-[var(--color-text-muted)]">
+                              {new Date(reply.created_at).toLocaleDateString('en-GB', {
+                                day: 'numeric',
+                                month: 'short',
+                                year: 'numeric',
+                              })}
+                            </span>
+                          </div>
+                          <button
+                            onClick={() => handleDelete(reply.id)}
+                            className="text-[var(--color-text-muted)] hover:text-red-500"
+                            title="Delete reply"
+                          >
+                            <Trash2 className="w-3 h-3" />
+                          </button>
+                        </div>
+                        <p className="text-sm text-[var(--color-text-secondary)] whitespace-pre-wrap">
+                          {reply.content}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import Image from 'next/image'
-import { PenLine, FileText, User, LogOut, Home, Users, Settings, Menu, X, Key, NotebookPen, Lightbulb } from 'lucide-react'
+import { PenLine, FileText, User, LogOut, Home, Users, Settings, Menu, X, Key, NotebookPen, Lightbulb, MessageSquareLock, BarChart3 } from 'lucide-react'
 import ThemeToggle from '@/components/common/ThemeToggle'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
 
@@ -16,6 +16,8 @@ interface DashboardLayoutProps {
 // Feature tooltip expiry: 5 days from first release
 const API_KEYS_FEATURE_DATE = new Date('2025-12-31').getTime()
 const SUGGESTIONS_FEATURE_DATE = new Date('2026-01-05').getTime()
+const CRITIQUES_FEATURE_DATE = new Date('2026-01-02').getTime()
+const ANALYTICS_FEATURE_DATE = new Date('2026-01-02').getTime()
 const TOOLTIP_DURATION_MS = 5 * 24 * 60 * 60 * 1000 // 5 days
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
@@ -25,6 +27,8 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [showApiKeysTooltip, setShowApiKeysTooltip] = useState(false)
   const [showSuggestionsTooltip, setShowSuggestionsTooltip] = useState(false)
+  const [showCritiquesTooltip, setShowCritiquesTooltip] = useState(false)
+  const [showAnalyticsTooltip, setShowAnalyticsTooltip] = useState(false)
   const [pendingRequestsCount, setPendingRequestsCount] = useState(0)
 
   const isAdmin = user?.role === 'admin' || user?.role === 'super_admin'
@@ -43,6 +47,12 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     }
     if (now < SUGGESTIONS_FEATURE_DATE + TOOLTIP_DURATION_MS) {
       setShowSuggestionsTooltip(true)
+    }
+    if (now < CRITIQUES_FEATURE_DATE + TOOLTIP_DURATION_MS) {
+      setShowCritiquesTooltip(true)
+    }
+    if (now < ANALYTICS_FEATURE_DATE + TOOLTIP_DURATION_MS) {
+      setShowAnalyticsTooltip(true)
     }
   }, [])
 
@@ -69,6 +79,8 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   const writerLinks = [
     { href: '/dashboard', label: 'My Posts', icon: FileText },
     { href: '/dashboard/new', label: 'New Post', icon: PenLine },
+    { href: '/dashboard/critiques', label: 'Critiques', icon: MessageSquareLock },
+    { href: '/dashboard/analytics', label: 'Analytics', icon: BarChart3 },
     { href: '/dashboard/suggestions', label: 'Suggestions', icon: Lightbulb },
     { href: '/dashboard/api-keys', label: 'API Keys', icon: Key },
     { href: '/dashboard/profile', label: 'Profile', icon: User },
@@ -79,6 +91,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     { href: '/admin/requests', label: 'Requests', icon: Users },
     { href: '/admin/members', label: 'Members', icon: Users },
     { href: '/admin/posts', label: 'All Posts', icon: FileText },
+    { href: '/admin/analytics', label: 'Platform Analytics', icon: BarChart3 },
   ]
 
   const superAdminLinks = [
@@ -218,6 +231,16 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                 >
                   <link.icon className="w-5 h-5" />
                   <span>{link.label}</span>
+                  {link.href === '/dashboard/critiques' && showCritiquesTooltip && (
+                    <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-cyan-800 text-white font-medium">
+                      New
+                    </span>
+                  )}
+                  {link.href === '/dashboard/analytics' && showAnalyticsTooltip && (
+                    <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-cyan-800 text-white font-medium">
+                      New
+                    </span>
+                  )}
                   {link.href === '/dashboard/api-keys' && showApiKeysTooltip && (
                     <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-cyan-800 text-white font-medium">
                       New
@@ -274,6 +297,11 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                     {link.href === '/admin/requests' && pendingRequestsCount > 0 && (
                       <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-cyan-800 text-white font-medium">
                         {pendingRequestsCount}
+                      </span>
+                    )}
+                    {link.href === '/admin/analytics' && showAnalyticsTooltip && (
+                      <span className="ml-auto text-xs px-1.5 py-0.5 rounded bg-cyan-800 text-white font-medium">
+                        New
                       </span>
                     )}
                   </Link>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -412,6 +412,76 @@ export async function sendNewReaderNotification({
   }
 }
 
+export async function sendNewCritiqueNotification({
+  to,
+  authorName,
+  postTitle,
+  postSlug,
+  critiquerName,
+}: {
+  to: string
+  authorName: string
+  postTitle: string
+  postSlug: string
+  critiquerName: string
+}) {
+  try {
+    const resend = getResendClient()
+    if (!resend) {
+      return { success: false, error: EMAIL_ERRORS.NOT_CONFIGURED }
+    }
+
+    const config = getEmailConfig()
+    const postUrl = `${config.appUrl}/post/${postSlug}`
+    const critiquesUrl = `${config.appUrl}/dashboard/critiques`
+
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${config.from}>`,
+      to: [to],
+      subject: `New critique on "${postTitle}"`,
+      html: `
+        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <h1 style="color: #0D9488; margin-bottom: 24px;">New Critique Received</h1>
+
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            Hi ${authorName},
+          </p>
+
+          <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+            <strong>${critiquerName}</strong> has left a critique on your article "<strong>${postTitle}</strong>".
+          </p>
+
+          <p style="color: #6b7280; font-size: 14px; line-height: 1.6;">
+            Critiques are private peer reviews visible only to you. They're meant to help improve your writing.
+          </p>
+
+          <a href="${critiquesUrl}" style="display: inline-block; background-color: #0D9488; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin-top: 16px;">
+            View Critique
+          </a>
+
+          <p style="color: #6b7280; font-size: 14px; margin-top: 32px;">
+            <a href="${postUrl}" style="color: #0D9488;">View your post</a>
+          </p>
+
+          <p style="color: #6b7280; font-size: 14px; margin-top: 16px;">
+            ${APP_NAME}
+          </p>
+        </div>
+      `,
+    })
+
+    if (error) {
+      console.error('Failed to send critique notification:', error)
+      return { success: false, error }
+    }
+
+    return { success: true, data }
+  } catch (error) {
+    console.error('Critique notification error:', error)
+    return { success: false, error }
+  }
+}
+
 export async function sendNewRequestNotification({
   name,
   username,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -343,3 +343,66 @@ export interface SuggestionFormData {
   title: string
   description?: string
 }
+
+// Critique types (private peer reviews)
+export interface Critique {
+  id: string
+  post_id: number
+  author_id: string
+  content: string
+  parent_id?: string
+  status: 'active' | 'deleted'
+  created_at: string
+  updated_at: string
+}
+
+export interface CritiqueWithAuthor extends Critique {
+  author: PublicUser
+  replies?: CritiqueWithAuthor[]
+}
+
+export interface CritiqueFormData {
+  content: string
+  parent_id?: string
+}
+
+// Analytics types
+export interface PageView {
+  id: string
+  post_id: number
+  viewed_at: string
+}
+
+export interface PostAnalytics {
+  post_id: number
+  title: string
+  normalized_title: string
+  views: number
+  reads: number
+  box_additions: number
+  bookmarks: number
+  comments: number
+  critiques: number
+}
+
+export interface WriterAnalytics {
+  total_posts: number
+  total_views: number
+  total_reads: number
+  total_box_additions: number
+  total_bookmarks: number
+  total_comments: number
+  total_critiques: number
+  posts: PostAnalytics[]
+}
+
+export interface AdminAnalytics {
+  total_users: number
+  total_writers: number
+  total_readers: number
+  total_posts: number
+  total_views: number
+  user_growth: { date: string; count: number }[]
+  content_growth: { date: string; count: number }[]
+  top_authors: { author: PublicUser; post_count: number; total_views: number }[]
+}


### PR DESCRIPTION
## Summary

- Add **Critiques** feature for private peer reviews between writers (only visible to post author)
- Add **Analytics Dashboard** with lightweight view tracking using `sendBeacon()`
- Track views, reads, box additions, comments, and critiques per post
- Email notifications when a writer receives a new critique
- "New" badges for Analytics and Critiques in navigation

## New Files

- `scripts/migration-critiques-analytics.sql` - Database migration
- `/dashboard/analytics` - Writer analytics page
- `/dashboard/critiques` - Critiques inbox
- `/admin/analytics` - Platform analytics (admin)
- API routes for critiques and analytics

## Test Plan

- [ ] Run database migration
- [ ] Verify analytics page shows stats for published posts
- [ ] Verify critiques can be submitted on other writers' posts
- [ ] Verify only post author can see critiques on their posts
- [ ] Verify email notification is sent for new critiques
- [ ] Verify view tracking works (check page_views table)